### PR TITLE
Use UTF-16 encoding for strings rather than UCS-2

### DIFF
--- a/src/libmtp.c
+++ b/src/libmtp.c
@@ -1875,8 +1875,8 @@ LIBMTP_mtpdevice_t *LIBMTP_Open_Raw_Device_Uncached(LIBMTP_raw_device_t *rawdevi
   current_params->error_func = LIBMTP_ptp_error;
   /* TODO: Will this always be little endian? */
   current_params->byteorder = PTP_DL_LE;
-  current_params->cd_locale_to_ucs2 = iconv_open("UCS-2LE", "UTF-8");
-  current_params->cd_ucs2_to_locale = iconv_open("UTF-8", "UCS-2LE");
+  current_params->cd_locale_to_ucs2 = iconv_open("UTF-16LE", "UTF-8");
+  current_params->cd_ucs2_to_locale = iconv_open("UTF-8", "UTF-16LE");
 
   if(current_params->cd_locale_to_ucs2 == (iconv_t) -1 ||
      current_params->cd_ucs2_to_locale == (iconv_t) -1) {


### PR DESCRIPTION
The MTP spec is somewhat ambiguous and says that:

Strings in PTP (and thus MTP) consist of standard 2-byte Unicode
characters as defined by ISO 10646.

This was interpreted to mean UCS-2 encoding, but I think that even
at the time the PTP spec was written, ISO 10646 had formally been
amended so that UTF-16 replaced UCS-2 as the 2-byte encoding.

We've gone a surprisingly long time without this being an issue, but
if you do try and construct a filename with supplementary plane
codepoints (most likely emoji characters in this day and age), libmtp
will fail to send or receive them.

Fortunately, as we use iconv, fixing this is a simple matter of
telling it to use UTF-16LE instead of UCS-2LE.

I did not attempt to rename any of the functions that include 'ucs2'
in their name. Let me know if you want me to do that.

Reported-by: Jerry Zhang <zhangjerry@google.com>