### PR TITLE
Downgrade a trace from error to info, plus whitespace cleanups

### DIFF
--- a/src/libopenusb1-glue.c
+++ b/src/libopenusb1-glue.c
@@ -500,7 +500,7 @@ static LIBMTP_error_number_t get_mtp_usb_device_list(mtpdevice_list_t ** mtp_dev
 
         ret = openusb_parse_device_desc(libmtp_openusb_handle, dev, NULL, 0, &desc);
         if (ret != OPENUSB_SUCCESS) continue;
-        
+
         if (desc.bDeviceClass != USB_CLASS_HUB) {
             int i;
             int found = 0;
@@ -651,7 +651,7 @@ LIBMTP_error_number_t LIBMTP_Detect_Raw_Devices(LIBMTP_raw_device_t ** devices,
                 retdevs[i].device_entry.device_flags = mtp_device_table[j].device_flags;
 
                 // This device is known to the developers
-                LIBMTP_ERROR("Device %d (VID=%04x and PID=%04x) is a %s %s.\n",
+                LIBMTP_INFO("Device %d (VID=%04x and PID=%04x) is a %s %s.\n",
                         i,
                         desc.idVendor,
                         desc.idProduct,
@@ -1239,7 +1239,7 @@ ptp_usb_senddata(PTPParams* params, PTPContainer* ptp,
         if (ret != PTP_RC_OK){
             return ret;
         }
-            
+
         if (gotlen != datawlen){
             return PTP_RC_GeneralError;
         }

--- a/src/libusb-glue.c
+++ b/src/libusb-glue.c
@@ -666,7 +666,7 @@ LIBMTP_error_number_t LIBMTP_Detect_Raw_Devices(LIBMTP_raw_device_t ** devices,
 	retdevs[i].device_entry.device_flags = mtp_device_table[j].device_flags;
 
 	// This device is known to the developers
-	LIBMTP_ERROR("Device %d (VID=%04x and PID=%04x) is a %s %s.\n",
+	LIBMTP_INFO("Device %d (VID=%04x and PID=%04x) is a %s %s.\n",
 		i,
 		dev->libusb_device->descriptor.idVendor,
 		dev->libusb_device->descriptor.idProduct,

--- a/src/libusb1-glue.c
+++ b/src/libusb1-glue.c
@@ -690,7 +690,7 @@ LIBMTP_error_number_t LIBMTP_Detect_Raw_Devices(LIBMTP_raw_device_t ** devices,
 	retdevs[i].device_entry.device_flags = mtp_device_table[j].device_flags;
 
 	// This device is known to the developers
-	LIBMTP_ERROR("Device %d (VID=%04x and PID=%04x) is a %s %s.\n",
+	LIBMTP_INFO("Device %d (VID=%04x and PID=%04x) is a %s %s.\n",
 		i,
 		desc.idVendor,
 		desc.idProduct,

--- a/src/util.c
+++ b/src/util.c
@@ -149,4 +149,3 @@ char *strndup (const char *s, size_t n)
   return ret;
 }
 #endif
-


### PR DESCRIPTION
This trace is happening a lot in my app, every time I detect connected devices... I guess it wasn't mean to be an error trace.

Also on an almost related note, there isn't a better way to poll for devices (detecting connection and deconnection) than... actually polling?