### PR TITLE
Blacklist DUALi NFC readers

### DIFF
--- a/util/mtp-hotplug.c
+++ b/util/mtp-hotplug.c
@@ -161,6 +161,8 @@ int main (int argc, char **argv)
       printf("ATTR{idVendor}==\"03eb\", GOTO=\"libmtp_rules_end\"\n");
       printf("# Sensitive Philips device\n");
       printf("ATTR{idVendor}==\"0471\", ATTR{idProduct}==\"083f\", GOTO=\"libmtp_rules_end\"\n");
+      printf("# DUALi NFC readers\n");
+      printf("ATTR{idVendor}==\"1db2\", ATTR{idProduct}==\"060*\", GOTO=\"libmtp_rules_end\"\n");
       break;
     case style_udev_old:
       printf("# UDEV-style hotplug map for libmtp\n");


### PR DESCRIPTION
Not sure if it is the correct way to deal with [this bug](https://bugs.launchpad.net/ubuntu/+source/libmtp/+bug/1560452), but at least now it is forwarded.