### PR TITLE
Switch doxygen FULL_PATH_NAMES to NO for reproducible builds

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -96,7 +96,7 @@ INLINE_INHERITED_MEMB  = NO
 # path before files name in the file list and in the header files. If set 
 # to NO the shortest path that makes the file name unique will be used.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # If the FULL_PATH_NAMES tag is set to YES then the STRIP_FROM_PATH tag 
 # can be used to strip a user-defined part of the path. Stripping is 


### PR DESCRIPTION
This is a [Debian patch](https://salsa.debian.org/debian/libmtp/blob/master/debian/patches/repro-doc.patch) to improve [reproducible builds](https://reproducible-builds.org/).

Gitlab-CI before the patch:
https://salsa.debian.org/debian/libmtp/-/jobs/540507

Gitlab-CI after the patch:
https://salsa.debian.org/debian/libmtp/-/jobs/540540