### PR TITLE
On UDEV discovery do not let printers get auto-probed (Closes #24)

### DIFF
--- a/util/mtp-hotplug.c
+++ b/util/mtp-hotplug.c
@@ -163,6 +163,10 @@ int main (int argc, char **argv)
       printf("ATTR{idVendor}==\"0471\", ATTR{idProduct}==\"083f\", GOTO=\"libmtp_rules_end\"\n");
       printf("# DUALi NFC readers\n");
       printf("ATTR{idVendor}==\"1db2\", ATTR{idProduct}==\"060*\", GOTO=\"libmtp_rules_end\"\n");
+      printf("# HP printers\n");
+      printf("ATTR{idVendor}==\"03f0\", ENV{ID_USB_INTERFACES}==\"*:0701??:*|*:ffcc00:\", GOTO=\"libmtp_rules_end\"\n");
+      printf("# Printers\n");
+      printf("ENV{ID_USB_INTERFACES}==\"*:0701??:*\", GOTO=\"libmtp_rules_end\"\n");
       break;
     case style_udev_old:
       printf("# UDEV-style hotplug map for libmtp\n");


### PR DESCRIPTION
Author: Till Kamppeter

Bug: https://github.com/libmtp/libmtp/issues/24 and https://sourceforge.net/p/libmtp/bugs/1697/
Bug-Debian: https://bugs.debian.org/954885
Bug-Ubuntu: https://bugs.launchpad.net/bugs/1863239

 Devices which are not explicitly known as supported by libmtp gwt auto-probed
 by mtp-probe. Unfortunately, many devices which are not audio or media players
 test positive on the auto-probing and so their USB device files get "audio"
 group ownership. making them inaccessible for the sub system which is actually
 responsible for them. Therefore there are also rules for skipping some
 devices.
 .
 This patch adds skipping rules for printers, as they have to belong to the
 "lp" group for CUPS or Printer Applications to be able to access them. The
 extra rule for HP printers covers some weird, proprietary devices from HP,
 it is copied from HPLIP