### PR TITLE
Add device id for Garmin Vivoactive 4S.

### DIFF
--- a/logs/mtp-detect-garmin-vivoactive4s.txt
+++ b/logs/mtp-detect-garmin-vivoactive4s.txt
@@ -1,0 +1,270 @@
+libmtp version: 1.1.13
+
+Listing raw device(s)
+   Found 1 device(s):
+   091e:4c98 @ bus 1, dev 9
+Attempting to connect device(s)
+USB low-level info:
+   bcdUSB: 512
+   bDeviceClass: 0
+   bDeviceSubClass: 0
+   bDeviceProtocol: 0
+   idVendor: 091e
+   idProduct: 4c98
+   IN endpoint maxpacket: 512 bytes
+   OUT endpoint maxpacket: 512 bytes
+   Raw device info:
+      Bus location: 1
+      Device number: 9
+      Device entry info:
+         Vendor: (null)
+         Vendor id: 0x091e
+         Product: (null)
+         Vendor id: 0x4c98
+         Device flags: 0x00000000
+Configuration 0, interface 0, altsetting 0:
+   Interface description contains the string "MTP"
+   Device recognized as MTP, no further probing.
+Device info:
+   Manufacturer: Garmin
+   Model: vívoactive 4S
+   Device version: 450
+   Serial number: 0000c5ac5c70
+   Vendor extension ID: 0x00000006
+   Vendor extension description: microsoft.com: 1.0; 
+   Detected object size: 64 bits
+   Extensions:
+        microsoft.com: 1.0
+Supported operations:
+   1003: Close session
+   100b: Delete object
+   1001: Get device info
+   1014: Get device property description
+   1015: Get device property value
+   1009: Get object
+   1007: Get object handles
+   1008: Get object info
+   9802: Get object property description
+   9805: Get object property list
+   9803: Get object property value
+   9801: Get object properties supported
+   101b: Get partial object
+   1004: Get storage IDs
+   1005: Get storage info
+   1019: Move object
+   1002: Open session
+   1010: Reset device
+   100d: Send object
+   100c: Send object info
+   1016: Set device property value
+   9804: Set object property value
+   9810: Get object references
+   9811: Set object references
+   100a: Get thumbnail
+   9000: Unknown PTP_OC
+   9001: Unknown PTP_OC
+   9002: Unknown PTP_OC
+   9003: Unknown PTP_OC
+   9004: Unknown PTP_OC
+   9005: Unknown PTP_OC
+   9006: Unknown PTP_OC
+   9008: Unknown PTP_OC
+Events supported:
+   0x4002 ((null))
+   0x4003 ((null))
+   0x4006 ((null))
+   0x4004 ((null))
+   0x4005 ((null))
+Device Properties Supported:
+   0x5011: Date & Time
+   0xd402: Friendly Device Name
+   0xd405: Device Icon
+   0xd407: Perceived Device Type
+Playable File (Object) Types and Object Properties Supported:
+   3801: JPEG
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+   3009: MP3
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+      dc89: Duration UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc46: Artist STRING data type READ ONLY
+      dc8b: Track UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc8c: Genre STRING data type READ ONLY
+      dc91: Use Count UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc9a: Album Name STRING data type READ ONLY
+      dc9b: Album Artist STRING data type READ ONLY
+      de93: Sample Rate UINT32 data type range: MIN 1000, MAX 96000, STEP 1 READ ONLY
+      de94: Number Of Channels UINT16 data type enumeration: 1, 2,  READ ONLY
+      de9a: Audio Bit Rate UINT32 data type range: MIN 1024, MAX 819200, STEP 1 READ ONLY
+      de99: Audio WAVE Codec UINT32 data type enumeration: 0, 1, 10, 80, 85, 146, 255, 353, 354, 355, 356, 5648,  READ ONLY
+   380b: PNG
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+   b982: MP4
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+      dc89: Duration UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc46: Artist STRING data type READ ONLY
+      dc8b: Track UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc8c: Genre STRING data type READ ONLY
+      dc91: Use Count UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc9a: Album Name STRING data type READ ONLY
+      dc9b: Album Artist STRING data type READ ONLY
+      de93: Sample Rate UINT32 data type range: MIN 1000, MAX 96000, STEP 1 READ ONLY
+      de94: Number Of Channels UINT16 data type enumeration: 1, 2,  READ ONLY
+      de99: Audio WAVE Codec UINT32 data type enumeration: 0, 1, 10, 80, 85, 146, 255, 353, 354, 355, 356, 5648,  READ ONLY
+      de9a: Audio Bit Rate UINT32 data type range: MIN 1024, MAX 819200, STEP 1 READ ONLY
+   ba11: M3U Playlist
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+      dc89: Duration UINT32 data type ANY 32BIT VALUE form READ ONLY
+   b903: AAC
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+      dc89: Duration UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc91: Use Count UINT32 data type ANY 32BIT VALUE form READ ONLY
+      de93: Sample Rate UINT32 data type range: MIN 1000, MAX 96000, STEP 1 READ ONLY
+      de94: Number Of Channels UINT16 data type enumeration: 1, 2,  READ ONLY
+      de99: Audio WAVE Codec UINT32 data type enumeration: 0, 1, 10, 80, 85, 146, 255, 353, 354, 355, 356, 5648,  READ ONLY
+      de9a: Audio Bit Rate UINT32 data type range: MIN 1024, MAX 819200, STEP 1 READ ONLY
+   3008: MS Wave
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+      dc89: Duration UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc91: Use Count UINT32 data type ANY 32BIT VALUE form READ ONLY
+      de93: Sample Rate UINT32 data type range: MIN 1000, MAX 96000, STEP 1 READ ONLY
+      de94: Number Of Channels UINT16 data type enumeration: 1, 2,  READ ONLY
+      de99: Audio WAVE Codec UINT32 data type enumeration: 0, 1, 10, 80, 85, 146, 255, 353, 354, 355, 356, 5648,  READ ONLY
+      de9a: Audio Bit Rate UINT32 data type range: MIN 1024, MAX 819200, STEP 1 READ ONLY
+   ba05: Abstract Audio Video Playlist
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+   3000: Undefined Type
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+   3001: Association/Directory
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form READ ONLY
+      dc04: Object Size UINT64 data type READ ONLY
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY
+      dc07: Object File Name STRING data type GET/SET
+      dc44: Name STRING data type READ ONLY
+      dc08: Date Created STRING data type DATETIME FORM READ ONLY
+      dc09: Date Modified STRING data type DATETIME FORM GET/SET
+      dc03: Protection Status UINT16 data type enumeration: 0, 1, 32770, 32771,  READ ONLY
+      dc4f: Non Consumable UINT8 data type enumeration: 0, 1,  READ ONLY
+Storage Devices:
+   StorageID: 0x00020001
+      StorageType: 0x0003 fixed RAM storage
+      FilesystemType: 0x0002 generic hierarchical
+      AccessCapability: 0x0000 read/write
+      MaxCapacity: 3872260096
+      FreeSpaceInBytes: 3813933056
+      FreeSpaceInObjects: 4294967295
+      StorageDescription: Primary
+      VolumeIdentifier: (null)
+Special directories:
+   Default music folder: 0xffffffff
+   Default playlist folder: 0xffffffff
+   Default picture folder: 0xffffffff
+   Default video folder: 0xffffffff
+   Default organizer folder: 0xffffffff
+   Default zencast folder: 0xffffffff
+   Default album folder: 0xffffffff
+   Default text folder: 0xffffffff
+MTP-specific device properties:
+   Friendly name: vívoactive 4S
+   Synchronization partner: (NULL)
+libmtp supported (playable) filetypes:
+   JPEG file
+   ISO MPEG-1 Audio Layer 3
+   Portable Network Graphics
+   MPEG-4 Part 14 Container Format (Audio+Video Emphasis)
+   Advanced Audio Coding (AAC)/MPEG-2 Part 7/MPEG-4 Part 3
+   RIFF WAVE file
+   Abstract Playlist file
+   Folder
+OK.

--- a/src/music-players.h
+++ b/src/music-players.h
@@ -3759,6 +3759,7 @@
   { "Garmin", 0x091e, "Fenix 5/5S/5X Plus", 0x4b54, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://sourceforge.net/p/libmtp/feature-requests/271/ */
   { "Garmin", 0x091e, "Vivoactive 3", 0x4bac, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Garmin", 0x091e, "Vivoactive 4S", 0x4c98, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://sourceforge.net/p/libmtp/bugs/1864/ */
   { "Garmin", 0x091e, "Venu", 0x4c9a, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://sourceforge.net/p/libmtp/bugs/1852/ */


### PR DESCRIPTION
Built and tested 1.1.17 on Ubuntu 18.04

```
prefix $ ./mtp-detect 
libmtp version: 1.1.17

Listing raw device(s)
Device 0 (VID=091e and PID=4c98) is a Garmin Vivoactive 4S.
   Found 1 device(s):
   Garmin: Vivoactive 4S (091e:4c98) @ bus 1, dev 3
Attempting to connect device(s)
...
OK.
```