### PR TITLE
Flag i.Beat Organix 2.0 with DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST.

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -1398,7 +1398,7 @@
   // DEVICE_FLAG_UNLOAD_DRIVER },
   // Reported by Anonymous SourceForge user
   {"TrekStor", 0x1e68, "i.Beat Organix 2.0", 0x0002,
-    DEVICE_FLAG_UNLOAD_DRIVER },
+    DEVICE_FLAG_UNLOAD_DRIVER | DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST },
 
   /* Also Thalia Toline. https://sourceforge.net/p/libmtp/bugs/1156/ */
   {"iRiver", 0x1e68, "Tolino Tab 7", 0x1002,


### PR DESCRIPTION
mtp-detect was able to get metadata successfully, but stuck a long time at the last steps.
Retrieving and sending files was not possible either.

I added the DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST flag and was then able to use the device normally.

mtp-detect runs fine now.
mtp-connect --sendfile was working fine.
mtp-filetree and other folder and file infos were accessible without issues.