### PR TITLE
Device ID parameter for "mtp-getfile" (optional)

### DIFF
--- a/examples/connect.c
+++ b/examples/connect.c
@@ -69,7 +69,11 @@ int main (int argc, char **argv)
 
   fprintf(stdout, "libmtp version: " LIBMTP_VERSION_STRING "\n\n");
 
-  device = LIBMTP_Get_First_Device();
+  if ((strncmp(basename(argv[0]),"mtp-getfile",11) == 0) || (strncmp(basename(argv[0]),"getfile",7) == 0))
+    device = getfile_device(argc,argv);
+  else
+    device = LIBMTP_Get_First_Device();
+
   if (device == NULL) {
     printf("No devices.\n");
     return 0;

--- a/examples/connect.c
+++ b/examples/connect.c
@@ -79,11 +79,11 @@ int main (int argc, char **argv)
 
   if ((strncmp(basename(argv[0]),"mtp-delfile",11) == 0) || (strncmp(basename(argv[0]),"delfile",7) == 0)) {
     ret = delfile_command(argc,argv);
-  } else if ((strncmp(basename(argv[0]),"mtp-getfile",13) == 0) || (strncmp(basename(argv[0]),"getfile",9) == 0)) {
+  } else if ((strncmp(basename(argv[0]),"mtp-getfile",11) == 0) || (strncmp(basename(argv[0]),"getfile",7) == 0)) {
     ret = getfile_command(argc,argv);
   } else if ((strncmp(basename(argv[0]),"mtp-newfolder",13) == 0) || (strncmp(basename(argv[0]),"newfolder",9) == 0)) {
     ret = newfolder_command(argc,argv);
-  } else if ((strncmp(basename(argv[0]),"mtp-sendfile",11) == 0) || (strncmp(basename(argv[0]),"sendfile",7) == 0)) {
+  } else if ((strncmp(basename(argv[0]),"mtp-sendfile",12) == 0) || (strncmp(basename(argv[0]),"sendfile",8) == 0)) {
     ret = sendfile_command(argc, argv);
   } else if ((strncmp(basename(argv[0]),"mtp-sendtr",10) == 0) || (strncmp(basename(argv[0]),"sendtr",6) == 0)) {
     ret = sendtrack_command(argc, argv);

--- a/examples/connect.h
+++ b/examples/connect.h
@@ -30,6 +30,7 @@ int sendfile_function(char *,char *);
 int sendfile_command(int, char **);
 void sendfile_usage(void);
 int getfile_function(char *,char *);
+LIBMTP_mtpdevice_t *getfile_device(int, char **);
 int getfile_command(int, char **);
 void getfile_usage(void);
 int newfolder_function(char *);

--- a/src/libmtp.c
+++ b/src/libmtp.c
@@ -1680,13 +1680,13 @@ static int set_object_u8(LIBMTP_mtpdevice_t *device, uint32_t const object_id,
 }
 
 /**
- * Get the first (as in "first in the list of") connected MTP device.
+ * Get connected MTP device by list position.
  * @return a device pointer.
  * @see LIBMTP_Get_Connected_Devices()
  */
-LIBMTP_mtpdevice_t *LIBMTP_Get_First_Device(void)
+LIBMTP_mtpdevice_t *LIBMTP_Get_Device(int device_nr)
 {
-  LIBMTP_mtpdevice_t *first_device = NULL;
+  LIBMTP_mtpdevice_t *device = NULL;
   LIBMTP_raw_device_t *devices;
   int numdevs;
   LIBMTP_error_number_t ret;
@@ -1701,9 +1701,24 @@ LIBMTP_mtpdevice_t *LIBMTP_Get_First_Device(void)
     return NULL;
   }
 
-  first_device = LIBMTP_Open_Raw_Device(&devices[0]);
+  if (device_nr < 0 || device_nr >= numdevs) {
+    free(devices);
+    return NULL;
+  }
+
+  device = LIBMTP_Open_Raw_Device(&devices[device_nr]);
   free(devices);
-  return first_device;
+  return device;
+}
+
+/**
+ * Get the first (as in "first in the list of") connected MTP device.
+ * @return a device pointer.
+ * @see LIBMTP_Get_Connected_Devices()
+ */
+LIBMTP_mtpdevice_t *LIBMTP_Get_First_Device(void)
+{
+  return LIBMTP_Get_Device(0);
 }
 
 /**

--- a/src/libmtp.h.in
+++ b/src/libmtp.h.in
@@ -842,6 +842,7 @@ int LIBMTP_Check_Specific_Device(int busno, int devno);
 LIBMTP_mtpdevice_t *LIBMTP_Open_Raw_Device(LIBMTP_raw_device_t *);
 LIBMTP_mtpdevice_t *LIBMTP_Open_Raw_Device_Uncached(LIBMTP_raw_device_t *);
 /* Begin old, legacy interface */
+LIBMTP_mtpdevice_t *LIBMTP_Get_Device(int);
 LIBMTP_mtpdevice_t *LIBMTP_Get_First_Device(void);
 LIBMTP_error_number_t LIBMTP_Get_Connected_Devices(LIBMTP_mtpdevice_t **);
 uint32_t LIBMTP_Number_Devices_In_List(LIBMTP_mtpdevice_t *);

--- a/src/libmtp.sym
+++ b/src/libmtp.sym
@@ -5,6 +5,7 @@ LIBMTP_Detect_Raw_Devices
 LIBMTP_Check_Specific_Device
 LIBMTP_Open_Raw_Device
 LIBMTP_Open_Raw_Device_Uncached
+LIBMTP_Get_Device
 LIBMTP_Get_First_Device
 LIBMTP_Get_Connected_Devices
 LIBMTP_Number_Devices_In_List


### PR DESCRIPTION
This change adds an optional parameter to "mtp-getfile" to specify the device ID, which is needed to get a file if more than one device is connected and the file is to be fetched from a different device than the first one. (The parameter is numeric and works similar to the already existing file ID / track ID parameter.)

If the new parameter is omitted, "mtp-getfile" works as before (defaulting to the first device).
