### PR TITLE
Device ID parameter for "mtp-delfile" (optional)

### DIFF
--- a/examples/connect.c
+++ b/examples/connect.c
@@ -69,7 +69,9 @@ int main (int argc, char **argv)
 
   fprintf(stdout, "libmtp version: " LIBMTP_VERSION_STRING "\n\n");
 
-  if ((strncmp(basename(argv[0]),"mtp-getfile",11) == 0) || (strncmp(basename(argv[0]),"getfile",7) == 0))
+  if ((strncmp(basename(argv[0]),"mtp-delfile",11) == 0) || (strncmp(basename(argv[0]),"delfile",7) == 0))
+    device = delfile_device(argc,argv);
+  else if ((strncmp(basename(argv[0]),"mtp-getfile",11) == 0) || (strncmp(basename(argv[0]),"getfile",7) == 0))
     device = getfile_device(argc,argv);
   else
     device = LIBMTP_Get_First_Device();

--- a/examples/connect.h
+++ b/examples/connect.h
@@ -21,6 +21,7 @@
  * Boston, MA 02111-1307, USA.
  */
 int delfile_function(char *);
+LIBMTP_mtpdevice_t *delfile_device(int, char **);
 int delfile_command(int, char **);
 void delfile_usage(void);
 int sendtrack_function (char *, char *, char *, char *, char *, char *, char *, char *, uint16_t, uint16_t, uint16_t, uint32_t, uint16_t);

--- a/examples/delfile.c
+++ b/examples/delfile.c
@@ -34,7 +34,7 @@ extern LIBMTP_file_t *files;
 
 void delfile_usage(void)
 {
-  printf("Usage: delfile -n <fileid/trackid> | -f <filename> ...\n");
+  printf("Usage: delfile [<deviceid>] -n <fileid/trackid> | -f <filename> ...\n");
 }
 
 int
@@ -56,21 +56,46 @@ delfile_function(char * path)
   return 0;
 }
 
+LIBMTP_mtpdevice_t *delfile_device(int argc, char **argv)
+{
+  if (argc >= 3 && argv[1][0] == '-')
+    return LIBMTP_Get_First_Device();
+
+  if (argc >= 4) {
+    uint32_t id;
+    char *endptr;
+
+    // Sanity check device ID
+    id = strtoul(argv[1], &endptr, 10);
+    if ( *endptr != 0 ) {
+      fprintf(stderr, "illegal value %s\n", argv[1]);
+      return NULL;
+    }
+
+    return LIBMTP_Get_Device(id);
+  }
+
+  delfile_usage();
+
+  return NULL;
+}
+
 int delfile_command(int argc, char **argv)
 {
   int FILENAME = 1;
   int ITEMID = 2;
   int field_type = 0;
   int i;
+  int off = (argc >= 4 && argv[1][0] != '-' ? 1 : 0);
   int ret = 0;
 
   if ( argc > 2 ) {
-    if (strncmp(argv[1],"-f",2) == 0) {
+    if (strncmp(argv[1 + off],"-f",2) == 0) {
       field_type = FILENAME;
-      strcpy(argv[1],"");
-    } else if (strncmp(argv[1],"-n",2) == 0) {
+      strcpy(argv[1 + off],"");
+    } else if (strncmp(argv[1 + off],"-n",2) == 0) {
       field_type = ITEMID;
-      strcpy(argv[1],"0");
+      strcpy(argv[1 + off],"0");
     } else {
       delfile_usage();
       return 0;
@@ -80,7 +105,7 @@ int delfile_command(int argc, char **argv)
     return 0;
   }
 
-  for (i=1;i<argc;i++) {
+  for (i=1+off;i<argc;i++) {
     uint32_t id;
     char *endptr;
 

--- a/examples/delfile.c
+++ b/examples/delfile.c
@@ -34,7 +34,7 @@ extern LIBMTP_file_t *files;
 
 void delfile_usage(void)
 {
-  printf("Usage: delfile [-n] <fileid/trackid> | -f <filename>\n");
+  printf("Usage: delfile -n <fileid/trackid> | -f <filename> ...\n");
 }
 
 int


### PR DESCRIPTION
This change adds an optional parameter to "mtp-delfile" to specify the device ID, which is needed to delete a file if more than one device is connected and the file is to be deleted from a different device than the first one. (The parameter is numeric and works similar to the already existing file ID / track ID parameter.)

If the new parameter is omitted, "mtp-delfile" works as before (defaulting to the first device).