### PR TITLE
Bugfix for return value in cancel and status request

### DIFF
--- a/src/libusb-glue.c
+++ b/src/libusb-glue.c
@@ -1645,7 +1645,7 @@ ptp_usb_control_cancel_request (PTPParams *params, uint32_t transactionid) {
 			      (char *) buffer,
 			      sizeof(buffer),
 			      ptp_usb->timeout);
-	if (ret < sizeof(buffer))
+	if (ret < (int)sizeof(buffer))
 		return PTP_ERROR_IO;
 	return PTP_RC_OK;
 }

--- a/src/libusb1-glue.c
+++ b/src/libusb1-glue.c
@@ -1852,7 +1852,7 @@ ptp_usb_control_cancel_request (PTPParams *params, uint32_t transactionid) {
 			      buffer,
 			      sizeof(buffer),
 			      ptp_usb->timeout);
-	if (ret < sizeof(buffer))
+	if (ret < (int)sizeof(buffer))
 		return PTP_ERROR_IO;
 	return PTP_RC_OK;
 }
@@ -1874,7 +1874,7 @@ ptp_usb_control_device_status_request (PTPParams *params) {
                   buffer,
                   sizeof(buffer),
                   ptp_usb->timeout);
-    if (ret < sizeof(buffer))
+    if (ret < (int)sizeof(buffer))
         return PTP_ERROR_IO;
 
     ret = dtoh16a(&buffer[2]);


### PR DESCRIPTION
Comparing signed integer (ret) with unsigned integer/size_t result of sizeof(buffer). `usb_control_msg` returns one of LIBUSB_ERROR (that has a negative value) or number of bytes transferred (positive value). The if condition remains false for "-1 < sizeof(buffer)" and function returns `PTP_RC_OK` instead of `PTP_ERROR_IO`. To solve this issue, explicitly cast sizeof result to signed int to make comparison correct. In this case there is no issue to reduce the range of sizeof, as by design control packets are small.

Signed-off-by: Artur Mądrzak <artur@madrzak.eu>