### PR TITLE
Device serial number parameter (optional) for "mtp-getfile" and "mtp-delfile"

### DIFF
--- a/examples/delfile.c
+++ b/examples/delfile.c
@@ -34,7 +34,7 @@ extern LIBMTP_file_t *files;
 
 void delfile_usage(void)
 {
-  printf("Usage: delfile [<deviceid>] -n <fileid/trackid> | -f <filename> ...\n");
+  printf("Usage: delfile [<deviceid> | SN:<serialnumber>] -n <fileid/trackid> | -f <filename> ...\n");
 }
 
 int
@@ -61,19 +61,8 @@ LIBMTP_mtpdevice_t *delfile_device(int argc, char **argv)
   if (argc >= 3 && argv[1][0] == '-')
     return LIBMTP_Get_First_Device();
 
-  if (argc >= 4) {
-    uint32_t id;
-    char *endptr;
-
-    // Sanity check device ID
-    id = strtoul(argv[1], &endptr, 10);
-    if ( *endptr != 0 ) {
-      fprintf(stderr, "illegal value %s\n", argv[1]);
-      return NULL;
-    }
-
-    return LIBMTP_Get_Device(id);
-  }
+  if (argc >= 4)
+    return LIBMTP_Get_Device_By_ID(argv[1]);
 
   delfile_usage();
 

--- a/examples/files.c
+++ b/examples/files.c
@@ -21,6 +21,7 @@
  * Boston, MA 02111-1307, USA.
  */
 #include "common.h"
+#include "ptp.h"
 #include <stdlib.h>
 
 static void dump_fileinfo(LIBMTP_file_t *file)
@@ -117,6 +118,7 @@ int main(int argc, char **argv)
   for (i = 0; i < numrawdevices; i++) {
     LIBMTP_mtpdevice_t *device;
     LIBMTP_devicestorage_t *storage;
+    PTPParams *params;
     char *friendlyname;
 
     device = LIBMTP_Open_Raw_Device_Uncached(&rawdevices[i]);
@@ -127,10 +129,13 @@ int main(int argc, char **argv)
 
     /* Echo the friendly name so we know which device we are working with */
     friendlyname = LIBMTP_Get_Friendlyname(device);
+    params = (PTPParams *) device->params;
     if (friendlyname == NULL) {
-      printf("Listing File Information on Device with name: (NULL)\n");
+      printf("Listing File Information on Device with name: (NULL) [SN:%s]\n",
+             params->deviceinfo.SerialNumber);
     } else {
-      printf("Listing File Information on Device with name: %s\n", friendlyname);
+      printf("Listing File Information on Device with name: %s [SN:%s]\n",
+             friendlyname, params->deviceinfo.SerialNumber);
       free(friendlyname);
     }
 

--- a/examples/getfile.c
+++ b/examples/getfile.c
@@ -33,7 +33,7 @@ extern LIBMTP_mtpdevice_t *device;
 
 void getfile_usage (void)
 {
-  fprintf(stderr, "getfile [<deviceid>] <fileid/trackid> <filename>\n");
+  fprintf(stderr, "getfile [<deviceid> | SN:<serialnumber>] <fileid/trackid> <filename>\n");
 }
 
 int
@@ -57,19 +57,8 @@ LIBMTP_mtpdevice_t *getfile_device(int argc, char **argv)
   if (argc == 3)
     return LIBMTP_Get_First_Device();
 
-  if (argc == 4) {
-    uint32_t id;
-    char *endptr;
-
-    // Sanity check device ID
-    id = strtoul(argv[1], &endptr, 10);
-    if ( *endptr != 0 ) {
-      fprintf(stderr, "illegal value %s\n", argv[1]);
-      return NULL;
-    }
-
-    return LIBMTP_Get_Device(id);
-  }
+  if (argc == 4)
+    return LIBMTP_Get_Device_By_ID(argv[1]);
 
   getfile_usage();
 

--- a/src/libmtp.h.in
+++ b/src/libmtp.h.in
@@ -844,6 +844,8 @@ LIBMTP_mtpdevice_t *LIBMTP_Open_Raw_Device_Uncached(LIBMTP_raw_device_t *);
 /* Begin old, legacy interface */
 LIBMTP_mtpdevice_t *LIBMTP_Get_Device(int);
 LIBMTP_mtpdevice_t *LIBMTP_Get_First_Device(void);
+LIBMTP_mtpdevice_t *LIBMTP_Get_Device_By_SerialNumber(char *);
+LIBMTP_mtpdevice_t *LIBMTP_Get_Device_By_ID(char *);
 LIBMTP_error_number_t LIBMTP_Get_Connected_Devices(LIBMTP_mtpdevice_t **);
 uint32_t LIBMTP_Number_Devices_In_List(LIBMTP_mtpdevice_t *);
 void LIBMTP_Release_Device_List(LIBMTP_mtpdevice_t*);

--- a/src/libmtp.sym
+++ b/src/libmtp.sym
@@ -7,6 +7,8 @@ LIBMTP_Open_Raw_Device
 LIBMTP_Open_Raw_Device_Uncached
 LIBMTP_Get_Device
 LIBMTP_Get_First_Device
+LIBMTP_Get_Device_By_SerialNumber
+LIBMTP_Get_Device_By_ID
 LIBMTP_Get_Connected_Devices
 LIBMTP_Number_Devices_In_List
 LIBMTP_Release_Device_List


### PR DESCRIPTION
This change adds an alternative to the optional device parameter of "mtp-getfile" and "mtp-delfile" to specify the device by serial number, which is needed to ensure that the file is fetched or deleted from the correct device even if the device order has changed between calling "mtp-files" (to see which files are available for fetching or deletion) and "mtp-getfile" or "mtp-delfile" later (to really fetch or delete the file).

Detailed description:

This optional parameter is used to work around consistency problems which may occur if several devices are connected and the list of devices changes after calling "mtp-files" and before calling "mtp-getfile" or "mtp-delfile", which may result in fatal results when attempting to fetch or delete files from the wrong device. (This can be caused either by connecting new or disconnecting existing devices after "mtp-files" was called, or by faulty devices or USB problems that result in devices being temporarily unavailable, all resulting in a list of devices for "mtp-getfile" or "mtp-delfile" that differ from the previous list of devices from "mtp-files".)

We encountered the described problems in an automated setup where many cameras are periodically connected and disconnected via USB on a customer system where cameras sporadically lock up every now and then, resulting in files being fetched from the wrong camera by "mtp-getfile" and (even worse) deleted from the wrong camera by "mtp-delfile".

The solution for the above scenario provided by the patches in this pull request adds the serial number of the device to the output of "mtp-files" (in brackets after the device name) and allows for specifying the device for "mtp-getfile" and "mtp-delfile" by optionally using the serial number (using the format "SN:<serial number>" to be distinguishable from the numeric device number) instead of the (also optional) position number in the list of devices. If this is the case, determining the correct device is done by comparing the serial number of the devices in the device list with the provided serial number parameter.

If this optional parameter is omitted, "mtp-getfile" and "mtp-delfile" work just as before.

If the addition of the serial number of the device to the output of "mtp-files" should be a problem, it could be limited to invocations that use a (yet to be added) optional parameter to "mtp-files". (In this case, please let me know, so I will add such an option, too.)