### PR TITLE
better Garmin Descent Mk2/Mk2i support

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -3794,11 +3794,12 @@
   /* https://sourceforge.net/p/libmtp/bugs/1864/ */
   { "Garmin", 0x091e, "Venu", 0x4c9a, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://sourceforge.net/p/libmtp/bugs/1852/ */
-  { "Garmin", 0x091e, "Descent Mk2i", 0x4cba, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Garmin", 0x091e, "Descent Mk2/Mk2i", 0x4cba, DEVICE_FLAGS_ANDROID_BUGS },
   { "Garmin", 0x091e, "Fenix 6", 0x4cda, DEVICE_FLAGS_ANDROID_BUGS },
   { "Garmin", 0x091e, "Fenix 6 Sapphire", 0x4cdb, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://sourceforge.net/p/libmtp/bugs/1887/ */
   { "Garmin", 0x091e, "Zumo XT", 0x4d9c, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Garmin", 0x091e, "Descent Mk2/Mk2i", 0x4e76, DEVICE_FLAGS_ANDROID_BUGS }, /* APAC version */
 
   /*
    * Wacom


### PR DESCRIPTION
I was able to verify with my friends at Garmin that the Mk2 and Mk2i both have
the same USB product id, but also that there are two different regional
versions of the device.
