### PR TITLE
Fix USB interface addressing for control packet

### DIFF
--- a/src/libusb1-glue.c
+++ b/src/libusb1-glue.c
@@ -1848,7 +1848,7 @@ ptp_usb_control_cancel_request (PTPParams *params, uint32_t transactionid) {
 	htod32a(&buffer[2],transactionid);
 	ret = libusb_control_transfer(ptp_usb->handle,
 			      LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
-                              0x64, 0x0000, 0x0000,
+                              0x64, 0x0000, ptp_usb->interface,
 			      buffer,
 			      sizeof(buffer),
 			      ptp_usb->timeout);
@@ -1870,7 +1870,7 @@ ptp_usb_control_device_status_request (PTPParams *params) {
 
     ret = libusb_control_transfer(ptp_usb->handle,
                   LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
-                  0x67, 0x0000, 0x0000,
+                  0x67, 0x0000, ptp_usb->interface,
                   buffer,
                   sizeof(buffer),
                   ptp_usb->timeout);


### PR DESCRIPTION
Async events (cancel and status) doesn't work for composite devices, when 
MTP interface is not located as the first one in the descriptors. Control transfers,
by default are addressed to interface 0 but should be addressed to
actual interface. For this purpose wIndex field should contain
address of target interface.

Signed-off-by: Artur Mądrzak <amadrzak@onplick.com>