### PR TITLE
Add Ricoh Theta V and Z1

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4021,6 +4021,12 @@
   { "GoPro" , 0x2672, "HERO7 Black", 0x0047, DEVICE_FLAG_NONE },
   { "GoPro" , 0x2672, "HERO8 Black", 0x0049, DEVICE_FLAG_NONE },
 
+  /* These Ricoh Theta cameras run Android but seem to work
+   * without DEVICE_FLAGS_ANDROID_BUGS.
+   */
+  { "Ricoh", 0x05ca, "Theta V (MTP)", 0x0368, DEVICE_FLAG_NONE },
+  { "Ricoh", 0x05ca, "Theta Z1 (MTP)", 0x036d, DEVICE_FLAG_NONE },
+
   /* https://sourceforge.net/p/libmtp/bugs/1490/ */
   { "Marshall" , 0x2ad9, "London", 0x000b, DEVICE_FLAG_NONE },
 


### PR DESCRIPTION
Note that these two cameras have an empty-string `StorageDescription`, see #67:

```
Device 0 (VID=05ca and PID=0368) is a Ricoh Theta V (MTP).
Attempting to connect device(s)
Device: (NULL)
Storage: (null)
```

To get the benefit of this PR them e.g. with GNOME GVFS based file managers, one thus needs this fix:

* https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/106

Adding these cams to the list, thus them getting the `ID_MTP_DEVICE` label via udev and mounted via `mtp://` instead of `gphoto2://` by `gvfs` **fixes > 4 GiB video file transfers being silently truncated to 4 GiB** and thus corrupted, see also:

* https://github.com/whoozle/android-file-transfer-linux/issues/250