### PR TITLE
Fix data read for single usb packet

### DIFF
--- a/src/libopenusb1-glue.c
+++ b/src/libopenusb1-glue.c
@@ -1361,6 +1361,10 @@ ptp_usb_getdata(PTPParams* params, PTPContainer* ptp, PTPDataHandler *handler) {
             if (putfunc_ret != PTP_RC_OK)
                 return putfunc_ret;
 
+            /* Nothing more left to read*/
+            if (rlen == usbdata.length)
+                return PTP_RC_OK;
+
             /* stuff data directly to passed data handler */
             while (1) {
                 unsigned long readdata;

--- a/src/libusb-glue.c
+++ b/src/libusb-glue.c
@@ -1349,6 +1349,10 @@ ptp_usb_getdata (PTPParams* params, PTPContainer* ptp, PTPDataHandler *handler)
 		  if (putfunc_ret != PTP_RC_OK)
 		    return putfunc_ret;
 
+		/* Nothing more left to read*/
+		if (rlen == usbdata.length)
+			return PTP_RC_OK;
+
 		  /* stuff data directly to passed data handler */
 		  while (1) {
 		    unsigned long readdata;

--- a/src/libusb1-glue.c
+++ b/src/libusb1-glue.c
@@ -1453,6 +1453,10 @@ ptp_usb_getdata (PTPParams* params, PTPContainer* ptp, PTPDataHandler *handler)
 		if (putfunc_ret != PTP_RC_OK)
 			return ptp_read_cancel_func(params, ptp->Transaction_ID);
 
+		/* Nothing more left to read*/
+		if (rlen == usbdata.length)
+			return PTP_RC_OK;
+
 		  /* stuff data directly to passed data handler */
 		  while (1) {
 		    unsigned long readdata;


### PR DESCRIPTION
For device, that sends combined header and data in single usb packet
ptp_getdata function issue USB read request where there is no more data
to be read. This leads to raise IO error, as device doesn't send anymore
data because it's already finished transfer.

Signed-off-by: Artur Mądrzak <artur@madrzak.eu>