### PR TITLE
Add mtp-detect log for the Volla Phone

### DIFF
--- a/logs/mtp-detect-volla-phone.txt
+++ b/logs/mtp-detect-volla-phone.txt
@@ -1,0 +1,466 @@
+libmtp version: 1.1.17
+
+Listing raw device(s)
+Device 0 (VID=18d1 and PID=7169) is UNKNOWN in libmtp v1.1.17.
+Please report this VID/PID and the device model to the libmtp development team
+   Found 1 device(s):
+   18d1:7169 @ bus 1, dev 14
+Attempting to connect device(s)
+PTP_ERROR_IO: failed to open session, trying again after resetting USB interface
+LIBMTP libusb: Attempt to reset device
+Android device detected, assigning default bug flags
+Error 1: Get Storage information failed.
+USB low-level info:
+   bcdUSB: 512
+   bDeviceClass: 0
+   bDeviceSubClass: 0
+   bDeviceProtocol: 0
+   idVendor: 18d1
+   idProduct: 7169
+   IN endpoint maxpacket: 512 bytes
+   OUT endpoint maxpacket: 512 bytes
+   Raw device info:
+      Bus location: 1
+      Device number: 14
+      Device entry info:
+         Vendor: (null)
+         Vendor id: 0x18d1
+         Product: (null)
+         Vendor id: 0x7169
+         Device flags: 0x18008106
+Configuration 0, interface 0, altsetting 0:
+   Interface description contains the string "MTP"
+   Device recognized as MTP, no further probing.
+Device info:
+   Manufacturer: Volla
+   Model: Phone
+   Device version: 1.0
+   Serial number: GS290CTM802143
+   Vendor extension ID: 0x00000006
+   Vendor extension description: microsoft.com: 1.0; android.com: 1.0;
+   Detected object size: 64 bits
+   Extensions:
+        microsoft.com: 1.0
+        android.com: 1.0
+Supported operations:
+   1001: Get device info
+   1002: Open session
+   1003: Close session
+   1004: Get storage IDs
+   1005: Get storage info
+   1006: Get number of objects
+   1007: Get object handles
+   1008: Get object info
+   1009: Get object
+   100a: Get thumbnail
+   100b: Delete object
+   100c: Send object info
+   100d: Send object
+   1014: Get device property description
+   1015: Get device property value
+   1016: Set device property value
+   1017: Reset device property value
+   1019: Move object
+   101b: Get partial object
+   9801: Get object properties supported
+   9802: Get object property description
+   9803: Get object property value
+   9804: Set object property value
+   9805: Get object property list
+   9810: Get object references
+   9811: Set object references
+   95c1: Get Partial Object (64bit Offset)
+   95c2: Send Partial Object
+   95c3: Truncate Object
+   95c4: Begin Edit Object
+   95c5: End Edit Object
+Events supported:
+   0x4002: ObjectAdded
+   0x4003: ObjectRemoved
+   0x4004: StoreAdded
+   0x4005: StoreRemoved
+   0x4006: DevicePropChanged
+   0x4007: ObjectInfoChanged
+   0xc801: ObjectPropChanged
+Device Properties Supported:
+   0xd402: Friendly Device Name
+   0xd401: Synchronization Partner
+Playable File (Object) Types and Object Properties Supported:
+   3000: Undefined Type
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3001: Association/Directory
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3004: Text
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3005: HTML
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3800: Defined Type
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3801: JPEG
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3802: TIFF EP
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3804: BMP
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3807: GIF
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3808: JFIF
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   380b: PNG
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   380d: TIFF
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   380e: TIFF_IT
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   380f: JP2
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3810: JPX
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   b902: OGG
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3009: MP3
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   3008: MS Wave
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   b901: WMA
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   b903: AAC
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   b906: FLAC
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   ba03: Abstract Audio Album
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+   ba05: Abstract Audio Video Playlist
+      dc01: Storage ID UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc0b: Parent Object UINT32 data type ANY 32BIT VALUE form GET/SET GROUP 0x0
+      dc02: Object Format UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc04: Object Size UINT64 data type READ ONLY GROUP 0x0
+      dc07: Object File Name STRING data type GET/SET GROUP 0x0
+      dce0: Display Name STRING data type GET/SET GROUP 0x0
+      dc41: Persistant Unique Object Identifier UINT128 data type READ ONLY GROUP 0x0
+      dc05: Association Type UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc06: Association Desc UINT32 data type ANY 32BIT VALUE form READ ONLY GROUP 0x0
+      dc03: Protection Status UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc08: Date Created STRING data type READ ONLY GROUP 0x0
+      dc09: Date Modified STRING data type READ ONLY GROUP 0x0
+      dc0d: Hidden UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+      dc4f: Non Consumable UINT16 data type ANY 16BIT VALUE form READ ONLY GROUP 0x0
+Special directories:
+   Default music folder: 0xffffffff
+   Default playlist folder: 0xffffffff
+   Default picture folder: 0xffffffff
+   Default video folder: 0xffffffff
+   Default organizer folder: 0xffffffff
+   Default zencast folder: 0xffffffff
+   Default album folder: 0xffffffff
+   Default text folder: 0xffffffff
+MTP-specific device properties:
+   Friendly name: (NULL)
+   Synchronization partner: (NULL)
+libmtp supported (playable) filetypes:
+   Folder
+   Text file
+   HTML file
+   JPEG file
+   BMP bitmap file
+   GIF bitmap file
+   JFIF file
+   Portable Network Graphics
+   TIFF bitmap file
+   JP2 file
+   JPX file
+   Ogg container format
+   ISO MPEG-1 Audio Layer 3
+   RIFF WAVE file
+   Microsoft Windows Media Audio
+   Advanced Audio Coding (AAC)/MPEG-2 Part 7/MPEG-4 Part 3
+   Free Lossless Audio Codec (FLAC)
+   Abstract Album file
+   Abstract Playlist file
+OK.


### PR DESCRIPTION
This is the log file of a [Volla Phone](https://volla.online) running [Ubuntu Touch](https://ubuntu-touch.io). Despite the unknown VID/PID this seems to work just fine. I was able to mount my device using [jmtpfs](https://github.com/JasonFerrara/jmtpfs) and browse through the files on the command line on Ubuntu 20.10.