### PR TITLE
fix(music-players.h): a missing device model Xiaomi MI 9

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -3686,6 +3686,9 @@
   /* https://sourceforge.net/p/libmtp/bugs/1445/ */
   { "Xiaomi", 0x2717, "Redmi 2 2014811 (MTP)", 0xff68,
       DEVICE_FLAGS_ANDROID_BUGS },
+  /* https://github.com/libmtp/libmtp/issues/90 */
+  { "Xiaomi", 0x0a9d, "MI 9 M1902F1G", 0xff40,
+      DEVICE_FLAGS_ANDROID_BUGS },
 
   /*
    * XO Learning Tablet


### PR DESCRIPTION
Adding a missing device model for Xiaomi MI 9 M1902F1G
Fixes #90