### PR TITLE
Fix array properties retrieval

### DIFF
--- a/src/ptp-pack.c
+++ b/src/ptp-pack.c
@@ -818,7 +818,7 @@ ptp_unpack_OI (PTPParams *params, unsigned char* data, PTPObjectInfo *oi, unsign
 							\
 	if (n >= UINT_MAX/sizeof(val->a.v[0]))		\
 		return 0;				\
-	if (n > (total - (*offset))/sizeof(val->a.v[0]))\
+	if (n > (total - (*offset))/sizeof(val->a.v[0].member))\
 		return 0;				\
 	val->a.count = n;				\
 	val->a.v = malloc(sizeof(val->a.v[0])*n);	\


### PR DESCRIPTION
The read data should be verified against target array data type, not the the whole PTPPropertyValue since it is a union and read data could be any of union types (including smaller than PTPPropertyValue size).
This might be not very straight explanation, so if you need an example feel free to ask.

I have doubts about line 819, but it seems it is checking if the target amount if PTPPropertyValue objects could be allocated, so check is valid.

Found it when tried to read the album image (RepresantativeSample) which is array of uint8.