### PR TITLE
Fix LIBMTP_STORAGE_SORTBY_MAXSPACE not working (copy-paste mistake)

### DIFF
--- a/src/libmtp.c
+++ b/src/libmtp.c
@@ -2980,7 +2980,7 @@ static int sort_storage_by(LIBMTP_mtpdevice_t *device,int const sortby)
 
       if (sortby == LIBMTP_STORAGE_SORTBY_FREESPACE && ptr1->FreeSpaceInBytes > ptr2->FreeSpaceInBytes)
         ptr2 = ptr1;
-      if (sortby == LIBMTP_STORAGE_SORTBY_MAXSPACE && ptr1->FreeSpaceInBytes > ptr2->FreeSpaceInBytes)
+      if (sortby == LIBMTP_STORAGE_SORTBY_MAXSPACE && ptr1->MaxCapacity > ptr2->MaxCapacity)
         ptr2 = ptr1;
 
       ptr1 = ptr1->next;


### PR DESCRIPTION
https://github.com/libmtp/libmtp/blob/08224127a6b270bf75fb4d025517e0bb9c1ec485/src/libmtp.c#L2980-L2983

This is clearly an error introduced by copy-paste that makes `LIBMTP_STORAGE_SORTBY_MAXSPACE` to behave just the same way as `LIBMTP_STORAGE_SORTBY_FREESPACE`.

It also partially relates to the problem described in #58.