### PR TITLE
feat: Add LIBMTP_Get_Children() to read the list of raw IDs of a folder.

### DIFF
--- a/src/libmtp.h.in
+++ b/src/libmtp.h.in
@@ -923,6 +923,10 @@ LIBMTP_file_t *LIBMTP_Get_Filelisting_With_Callback(LIBMTP_mtpdevice_t *,
 LIBMTP_file_t * LIBMTP_Get_Files_And_Folders(LIBMTP_mtpdevice_t *,
 					     uint32_t const,
 					     uint32_t const);
+int LIBMTP_Get_Children(LIBMTP_mtpdevice_t *,
+                        uint32_t const,
+                        uint32_t const,
+                        uint32_t **);
 LIBMTP_file_t *LIBMTP_Get_Filemetadata(LIBMTP_mtpdevice_t *, uint32_t const);
 int LIBMTP_Get_File_To_File(LIBMTP_mtpdevice_t*, uint32_t, char const * const,
 			LIBMTP_progressfunc_t const, void const * const);

--- a/src/libmtp.sym
+++ b/src/libmtp.sym
@@ -51,6 +51,7 @@ LIBMTP_Get_Filetype_Description
 LIBMTP_Get_Filelisting
 LIBMTP_Get_Filelisting_With_Callback
 LIBMTP_Get_Files_And_Folders
+LIBMTP_Get_Children
 LIBMTP_Get_Filemetadata
 LIBMTP_Get_File_To_File
 LIBMTP_Get_File_To_File_Descriptor


### PR DESCRIPTION
It will be blocked long time with LIBMTP_Get_Files_And_Folders function if there are many files in one folder. Cherry-pick this patch from chromium in order to implement a async function for gvfs backend.

Log: new LIBMTP_Get_Children() API.