### PR TITLE
libusb-glue: check return value of ptp_init_send_memory_handler

### DIFF
--- a/src/libopenusb1-glue.c
+++ b/src/libopenusb1-glue.c
@@ -1179,7 +1179,10 @@ ptp_usb_sendreq(PTPParams* params, PTPContainer* req, int dataphase) {
     usbreq.payload.params.param5 = htod32(req->Param5);
     /* send it to responder */
     towrite = PTP_USB_BULK_REQ_LEN - (sizeof (uint32_t)*(5 - req->Nparam));
-    ptp_init_send_memory_handler(&memhandler, (unsigned char*) &usbreq, towrite);
+    ret = ptp_init_send_memory_handler(&memhandler, (unsigned char*) &usbreq, towrite);
+    if (ret != PTP_RC_OK) {
+        return ret;
+    }
     ret = ptp_write_func(
             towrite,
             &memhandler,
@@ -1244,7 +1247,10 @@ ptp_usb_senddata(PTPParams* params, PTPContainer* ptp,
             return PTP_RC_GeneralError;
         }
     }
-    ptp_init_send_memory_handler(&memhandler, (unsigned char *) &usbdata, wlen);
+    ret = ptp_init_send_memory_handler(&memhandler, (unsigned char *) &usbdata, wlen);
+    if (ret != PTP_RC_OK) {
+        return ret;
+    }
     /* send first part of data */
     ret = ptp_write_func(wlen, &memhandler, params->data, &written);
     ptp_exit_send_memory_handler(&memhandler);

--- a/src/libusb-glue.c
+++ b/src/libusb-glue.c
@@ -1171,7 +1171,10 @@ ptp_usb_sendreq (PTPParams* params, PTPContainer* req, int dataphase)
 	usbreq.payload.params.param5=htod32(req->Param5);
 	/* send it to responder */
 	towrite = PTP_USB_BULK_REQ_LEN-(sizeof(uint32_t)*(5-req->Nparam));
-	ptp_init_send_memory_handler (&memhandler, (unsigned char*)&usbreq, towrite);
+	ret = ptp_init_send_memory_handler (&memhandler, (unsigned char*)&usbreq, towrite);
+	if (ret != PTP_RC_OK) {
+		return ret;
+	}
 	ret=ptp_write_func(
 		towrite,
 		&memhandler,
@@ -1234,7 +1237,10 @@ ptp_usb_senddata (PTPParams* params, PTPContainer* ptp,
 		if (gotlen != datawlen)
 			return PTP_RC_GeneralError;
 	}
-	ptp_init_send_memory_handler (&memhandler, (unsigned char *)&usbdata, wlen);
+	ret = ptp_init_send_memory_handler (&memhandler, (unsigned char *)&usbdata, wlen);
+	if (ret != PTP_RC_OK) {
+		return ret;
+	}
 	/* send first part of data */
 	ret = ptp_write_func(wlen, &memhandler, params->data, &written);
 	ptp_exit_send_memory_handler (&memhandler);

--- a/src/libusb1-glue.c
+++ b/src/libusb1-glue.c
@@ -1278,7 +1278,10 @@ ptp_usb_sendreq (PTPParams* params, PTPContainer* req, int dataphase)
 	usbreq.payload.params.param5=htod32(req->Param5);
 	/* send it to responder */
 	towrite = PTP_USB_BULK_REQ_LEN-(sizeof(uint32_t)*(5-req->Nparam));
-	ptp_init_send_memory_handler (&memhandler, (unsigned char*)&usbreq, towrite);
+	ret = ptp_init_send_memory_handler (&memhandler, (unsigned char*)&usbreq, towrite);
+	if (ret != PTP_RC_OK) {
+		return ret;
+	}
 	ret=ptp_write_func(
 		towrite,
 		&memhandler,
@@ -1341,7 +1344,10 @@ ptp_usb_senddata (PTPParams* params, PTPContainer* ptp,
 		if (gotlen != datawlen)
 			return PTP_RC_GeneralError;
 	}
-	ptp_init_send_memory_handler (&memhandler, (unsigned char *)&usbdata, wlen);
+	ret = ptp_init_send_memory_handler (&memhandler, (unsigned char *)&usbdata, wlen);
+	if (ret != PTP_RC_OK) {
+		return ret;
+	}
 	/* send first part of data */
 	ret = ptp_write_func(wlen, &memhandler, params->data, &written);
 	ptp_exit_send_memory_handler (&memhandler);


### PR DESCRIPTION
In case calling uninitialized function pointer and free uninitialized data pointer.

Signed-off-by: Qiuhao Li <Qiuhao.Li@outlook.com>