### PR TITLE
ptp_pack_string: check string length for no iconv situation

### DIFF
--- a/src/ptp-pack.c
+++ b/src/ptp-pack.c
@@ -212,13 +212,13 @@ ptp_pack_string(PTPParams *params, char *string, unsigned char* data, uint16_t o
 	uint16_t ucs2str[PTP_MAXSTRLEN+1];
 	char *ucs2strp = (char *) ucs2str;
 	size_t convlen = strlen(string);
+	size_t convmax = PTP_MAXSTRLEN * 2; /* Includes the terminator */
 
 	/* Cannot exceed 255 (PTP_MAXSTRLEN) since it is a single byte, duh ... */
 	memset(ucs2strp, 0, sizeof(ucs2str));  /* XXX: necessary? */
 #if defined(HAVE_ICONV) && defined(HAVE_LANGINFO_H)
 	if (params->cd_locale_to_ucs2 != (iconv_t)-1) {
 		size_t nconv;
-		size_t convmax = PTP_MAXSTRLEN * 2; /* Includes the terminator */
 		char *stringp = string;
 
 		nconv = iconv(params->cd_locale_to_ucs2, &stringp, &convlen,
@@ -230,10 +230,10 @@ ptp_pack_string(PTPParams *params, char *string, unsigned char* data, uint16_t o
 	{
 		unsigned int i;
 
-		for (i=0;i<convlen;i++) {
+		for (i=0;i<convlen && i<convmax;i++) {
 			ucs2str[i] = string[i];
 		}
-		ucs2str[convlen] = 0;
+		ucs2str[i] = 0;
 	}
 	/*
 	 * XXX: isn't packedlen just ( (uint16_t *)ucs2strp - ucs2str )?


### PR DESCRIPTION
When HAVE_ICONV or HAVE_LANGINFO_H is not defined, we may have stack-over-flow issue when copy string to ucs2str.

Signed-off-by: Qiuhao Li <Qiuhao.Li@outlook.com>