### PR TITLE
ptp-pack: fix #134 regression ucs2str overflow

### DIFF
--- a/src/ptp-pack.c
+++ b/src/ptp-pack.c
@@ -229,8 +229,10 @@ ptp_pack_string(PTPParams *params, char *string, unsigned char* data, uint16_t o
 #endif
 	{
 		unsigned int i;
-
-		for (i=0;i<convlen && i<convmax;i++) {
+		if (convlen > PTP_MAXSTRLEN) {
+			convlen = PTP_MAXSTRLEN;
+		}
+		for (i=0;i<convlen;i++) {
 			ucs2str[i] = string[i];
 		}
 		ucs2str[i] = 0;


### PR DESCRIPTION
As noell pointed out [1], PR #134 only partially fix the overflow issue of ucs2str. ucs2str can still be overflowed ~PTP_MAXSTRLEN bytes when convlen equals convmax (PTP_MAXSTRLEN * 2).

[1] https://github.com/libmtp/libmtp/commit/2ada8d587bbfb077f3b7155ebd0dfa8db65e935d#r91371167

Signed-off-by: Qiuhao Li <Qiuhao.Li@outlook.com>