### PR TITLE
Make mtp-hotplug used at build time configurable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,23 +9,25 @@ EXTRA_DIST=libmtp.pc libmtp.sh COPYING README.windows.txt RELEASE-CHECKLIST.md
 # This stuff only makes sense on Linux so only
 # build and ship it on Linux.
 if USE_LINUX
+MTP_HOTPLUG = util/mtp-hotplug
+
 udevrulesdir=@UDEV@/rules.d
 hwdbdir=@UDEV@/hwdb.d
 udevrules_DATA=@UDEV_RULES@
 hwdb_DATA=69-libmtp.hwdb
 noinst_DATA=libmtp.usermap libmtp.fdi
 
-libmtp.usermap: util/mtp-hotplug
-	util/mtp-hotplug > libmtp.usermap
+libmtp.usermap: $(MTP_HOTPLUG)
+	$(MTP_HOTPLUG) > libmtp.usermap
 
-@UDEV_RULES@: util/mtp-hotplug
-	util/mtp-hotplug -u -p"@UDEV@" @UDEV_GROUP@ @UDEV_MODE@ > @UDEV_RULES@
+@UDEV_RULES@: $(MTP_HOTPLUG)
+	$(MTP_HOTPLUG) -u -p"@UDEV@" @UDEV_GROUP@ @UDEV_MODE@ > @UDEV_RULES@
 
-libmtp.fdi: util/mtp-hotplug
-	util/mtp-hotplug -H > libmtp.fdi
+libmtp.fdi: $(MTP_HOTPLUG)
+	$(MTP_HOTPLUG) -H > libmtp.fdi
 
-$(hwdb_DATA): util/mtp-hotplug
-	util/mtp-hotplug -w > $(hwdb_DATA)
+$(hwdb_DATA): $(MTP_HOTPLUG)
+	$(MTP_HOTPLUG) -w > $(hwdb_DATA)
 
 CLEANFILES = libmtp.usermap @UDEV_RULES@ libmtp.fdi libmtp.hwdb
 endif


### PR DESCRIPTION
When cross-compiling, util/mtp-hotplug won't be executable on the system doing the build, so it's useful to be able to substitute that system's mtp-hotplug.

This will remove the need for hacks like [this one][1] in Void Linux.

[1]: https://github.com/void-linux/void-packages/blob/2577eb40bb584ef78c4644c307bed615f255511c/srcpkgs/libmtp/template#L23-L25