### PR TITLE
util/mtp-hotplug -W

### DIFF
--- a/util/mtp-hotplug.c
+++ b/util/mtp-hotplug.c
@@ -298,6 +298,7 @@ int main (int argc, char **argv)
           printf("\t%04x  %s %s\n", entry->product_id, entry->vendor, entry->product);
         break;
       case style_hwdb:
+          entry = &entries[sorted_codes[i]];
           printf("# %s %s\n", entry->vendor, entry->product);
           printf("usb:v%04Xp%04X*\n", entry->vendor_id, entry->product_id);
           printf(" ID_MEDIA_PLAYER=1\n");


### PR DESCRIPTION
Assemble 69-libmtp.hwdb sorted by idVendor:idProduct.

This can be considered a minor improvement if doing a binary search of this database by idVendor:idProduct (It is better to sort this database once during build versus sorting everytime this database is loaded).

This option was quick to create since most of the code exists already for mtp-hotplug -f

NOTE: If the database is searched sequentially, then there's no speed improvement with util/mtp-hotplug -W