### PR TITLE
Set mtp-hotplug default directory to match ./configure --with-udev=DIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,7 @@ AC_ARG_WITH(udev,
     AS_HELP_STRING([--with-udev=DIR],
     [directory where udev is installed [default=/usr/lib/udev]]),
     [UDEV="${withval}"], [])
+AC_DEFINE_UNQUOTED([UDEV_DIR], ["${UDEV}/"], [where mtp-probe is installed, default=/usr/lib/udev/])
 AC_SUBST(UDEV)
 
 # Optionally set name of udev rules file, default

--- a/util/mtp-hotplug.c
+++ b/util/mtp-hotplug.c
@@ -20,6 +20,7 @@
  * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
  */
+#include "config.h"
 #include <libmtp.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -75,7 +76,7 @@ int main (int argc, char **argv)
 
   char *action = NULL; // To hold the action when specified by the user.
   uint16_t last_vendor = 0x0000U;
-  char mtp_probe_dir[256] = "/usr/lib/udev/";
+  char mtp_probe_dir[256] = UDEV_DIR;
   char *udev_group= NULL;
   char *udev_mode = NULL;
   int *sorted_codes;


### PR DESCRIPTION
Looking at bug report here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=642552
and going to the bottom of the page caught my eye with:
+TEST!="/lib/udev/mtp-probe"
which is a different location from the hardcoded location in util/mtp-hotplug

Not everyone remembers to add -p, or inspect the results of 69-libmtp.rules to ensure it's right, so
this patch makes it so that util/hotplug also defaults to the project's assigned location of:
./configure --with-udev=DIR