### PR TITLE
Make a working'make distcheck', and therefore also a working 'make dist'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,18 +4,15 @@ ACLOCAL_AMFLAGS=-I m4
 pkgconfigdir=$(libdir)/pkgconfig
 pkgconfig_DATA=libmtp.pc
 
-EXTRA_DIST=libmtp.pc libmtp.sh COPYING README.windows.txt RELEASE-CHECKLIST.md
+EXTRA_DIST = autogen.sh libmtp.pc libmtp.sh COPYING README.windows.txt RELEASE-CHECKLIST.md sync-usbids.sh
+nodist_EXTRA_DATA = .git .github .travis-translate-pkgs .travis.yml
+DISTCHECK_CONFIGURE_FLAGS = --with-udev-group=nobody --with-udev-mode=760, --disable-mtpz
 
 # This stuff only makes sense on Linux so only
 # build and ship it on Linux.
 if USE_LINUX
 MTP_HOTPLUG = util/mtp-hotplug
-
-udevrulesdir=@UDEV@/rules.d
-hwdbdir=@UDEV@/hwdb.d
-udevrules_DATA=@UDEV_RULES@
-hwdb_DATA=69-libmtp.hwdb
-noinst_DATA=libmtp.usermap libmtp.fdi
+@UDEVdata_SNIPPET@
 
 libmtp.usermap: $(MTP_HOTPLUG)
 	$(MTP_HOTPLUG) > libmtp.usermap
@@ -29,5 +26,5 @@ libmtp.fdi: $(MTP_HOTPLUG)
 $(hwdb_DATA): $(MTP_HOTPLUG)
 	$(MTP_HOTPLUG) -w > $(hwdb_DATA)
 
-CLEANFILES = libmtp.usermap @UDEV_RULES@ libmtp.fdi libmtp.hwdb
+CLEANFILES = libmtp.usermap @UDEV_RULES@ libmtp.fdi 69-libmtp.hwdb
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,37 @@ AC_ARG_WITH(udev,
     [UDEV="${withval}"], [])
 AC_DEFINE_UNQUOTED([UDEV_DIR], ["${UDEV}/"], [where mtp-probe is installed, default=/usr/lib/udev/])
 AC_SUBST(UDEV)
+dnl NOTE: Since the (default) UDEV directory is not part of libmtp,
+dnl we cannot do a 'make distcheck' with it as a non-root user, so
+dnl we need to skip INSTALL or UNINSTALL during 'make distcheck'.
+dnl Do this here since automake can't process 'if/else/endif in Makefile.am
+UDEVdata_SNIPPET='
+noinst_DATA = libmtp.fdi libmtp.usermap
+ifeq ($(shell id -u),0)
+    udevrulesdir = $(UDEV)/rules.d
+    hwdbdir = $(UDEV)/hwdb.d
+    udevrules_DATA=@UDEV_RULES@
+    hwdb_DATA=69-libmtp.hwdb
+else
+    noinst_DATA += 69-libmtp.hwdb $(UDEV_RULES)
+endif
+no_DIST = 69-libmtp.hwdb $(UDEV_RULES) libmtp.fdi libmtp.usermap
+'
+AC_SUBST([UDEVdata_SNIPPET])
+AM_SUBST_NOTMAKE([UDEVdata_SNIPPET])
+UDEVbin_SNIPPET='
+mtp_probe_SOURCES = mtp-probe.c
+ifeq ($(shell id -u),0)
+    mtp_probe_PROGRAMS = mtp-probe
+    mtp_probedir = $(UDEV)
+else
+    bin_PROGRAMS += mtp-probe
+    noinst_PROGRAMS = mtp-probe
+    EXTRA_DIST = mtp-probe.c
+endif
+'
+AC_SUBST([UDEVbin_SNIPPET])
+AM_SUBST_NOTMAKE([UDEVbin_SNIPPET])
 
 # Optionally set name of udev rules file, default
 # priority is 69, to appear before 70-acl.rules which handles

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,24 +6,34 @@ libmtp_la_SOURCES = libmtp.c unicode.c unicode.h util.c util.h playlist-spl.c \
 	music-players.h device-flags.h playlist-spl.h mtpz.h \
 	chdk_live_view.h chdk_ptp.h
 
+EXTRA_DIST = gphoto2-sync.sh libmtp.h.in libmtp.sym ptp-pack.c
+nodist_EXTRA_DATA = libmtp.h
+
 if MTPZ_COMPILE
 libmtp_la_SOURCES += mtpz.c
+else
+EXTRA_DIST += mtpz.c
 endif
 
 if LIBUSB1_COMPILE
 libmtp_la_SOURCES += libusb1-glue.c
+else
+EXTRA_DIST += libusb1-glue.c
 endif
 
 if LIBUSB0_COMPILE
 libmtp_la_SOURCES += libusb-glue.c
+else
+EXTRA_DIST += libusb-glue.c
 endif
 
 if LIBOPENUSB_COMPILE
 libmtp_la_SOURCES += libopenusb1-glue.c
+else
+EXTRA_DIST += libopenusb1-glue.c
 endif
 
-include_HEADERS=libmtp.h
-EXTRA_DIST=libmtp.h.in libmtp.sym ptp-pack.c
+include_HEADERS = libmtp.h
 
 # ---------------------------------------------------------------------------
 # Advanced information about versioning:

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -2,9 +2,7 @@ if USE_LINUX
 bin_PROGRAMS=mtp-hotplug
 mtp_hotplug_SOURCES=mtp-hotplug.c
 
-mtp_probedir=@UDEV@
-mtp_probe_PROGRAMS=mtp-probe
-mtp_probe_SOURCES=mtp-probe.c
+@UDEVbin_SNIPPET@
 endif
 
 AM_CPPFLAGS=-I$(top_builddir)/src


### PR DESCRIPTION
Challenge was to get make distcheck to work with non-owned udev directories since normally 'make dist' and 'make distcheck' are done as user, not as root. This required two SNIPPETs injected from the configure.ac file, through automake, into the Makefile

A working 'make dist' allows you to create a working dist.tar that could be used on operating systems with semi-working, or broken autoconf/automake, or by users who don't have autoconf tools installed.