### PR TITLE
corrections to distcheck - can't use else in configure.ac snippet

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,15 @@ DISTCHECK_CONFIGURE_FLAGS = --with-udev-group=nobody --with-udev-mode=760, --dis
 # build and ship it on Linux.
 if USE_LINUX
 MTP_HOTPLUG = util/mtp-hotplug
+
+udevrules_DATA=@UDEV_RULES@
+udevrulesdir = $(datadir)
+hwdb_DATA=69-libmtp.hwdb
+hwdbdir = $(datadir)
 @UDEVdata_SNIPPET@
+
+noinst_DATA = libmtp.fdi libmtp.usermap
+no_DIST = 69-libmtp.hwdb $(UDEV_RULES) libmtp.fdi libmtp.usermap
 
 libmtp.usermap: $(MTP_HOTPLUG)
 	$(MTP_HOTPLUG) > libmtp.usermap

--- a/configure.ac
+++ b/configure.ac
@@ -31,10 +31,6 @@ noinst_DATA = libmtp.fdi libmtp.usermap
 ifeq ($(shell id -u),0)
     udevrulesdir = $(UDEV)/rules.d
     hwdbdir = $(UDEV)/hwdb.d
-    udevrules_DATA=@UDEV_RULES@
-    hwdb_DATA=69-libmtp.hwdb
-else
-    noinst_DATA += 69-libmtp.hwdb $(UDEV_RULES)
 endif
 no_DIST = 69-libmtp.hwdb $(UDEV_RULES) libmtp.fdi libmtp.usermap
 '
@@ -43,12 +39,7 @@ AM_SUBST_NOTMAKE([UDEVdata_SNIPPET])
 UDEVbin_SNIPPET='
 mtp_probe_SOURCES = mtp-probe.c
 ifeq ($(shell id -u),0)
-    mtp_probe_PROGRAMS = mtp-probe
     mtp_probedir = $(UDEV)
-else
-    bin_PROGRAMS += mtp-probe
-    noinst_PROGRAMS = mtp-probe
-    EXTRA_DIST = mtp-probe.c
 endif
 '
 AC_SUBST([UDEVbin_SNIPPET])

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -2,6 +2,9 @@ if USE_LINUX
 bin_PROGRAMS=mtp-hotplug
 mtp_hotplug_SOURCES=mtp-hotplug.c
 
+mtp_probe_SOURCES = mtp-probe.c
+mtp_probe_PROGRAMS = mtp-probe
+mtp_probedir = $(bindir)
 @UDEVbin_SNIPPET@
 endif
 


### PR DESCRIPTION
Sorry about the 'make install' mess since I didn't test the 'make install' until I got to a PC that could be messed-up if something went wrong.

Looking at it, I had to look back at [some other code I made earlier](https://github.com/JoesCat/gimp-fix-ca/commit/2d8106490a98118250712e4c02b2f0829e57ac1b) to see why 'make install' wasn't installing even though it was doing a 'make distcheck' until completion.

Seems I had to simplify libmtp's configure.ac further to remove the 'else' in the snippets.
'make install' and 'make distcheck' work with this fix.