### PR TITLE
Check for iconv_open() before building project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Create configure
         run: |
-          brew install autoconf automake libtool gcc libgcrypt
+          brew install autoconf automake libtool gcc libgcrypt libiconv
           touch ./config.rpath
           aclocal
           autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -240,6 +240,15 @@ AC_HEADER_TIME
 AC_CHECK_HEADERS([ctype.h errno.h fcntl.h getopt.h libgen.h \
 	limits.h stdio.h string.h sys/stat.h sys/time.h unistd.h \
 	langinfo.h locale.h arpa/inet.h byteswap.h sys/uio.h])
+dnl glibc>=2.1 has iconv_open(), but older glibc or distros, and
+dnl other OSes will need to install libiconv before building libmtp
+dnl see Installation info: https://www.gnu.org/software/libiconv/
+have_iconv=no
+AC_CHECK_HEADERS([iconv.h],[AC_CHECK_FUNC([iconv_open],[have_iconv=yes])])
+if test x"$have_iconv" = "xno" ; then
+	AC_SEARCH_LIBS([iconv],[have_iconv=yes],[
+	AC_MSG_ERROR([*** ERROR! iconv_open() required! Please install libiconv first. ***])])
+fi
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST


### PR DESCRIPTION
Older glibc or distros, or OSes may still be depending on libiconv. If you can't find iconv_open(), remind user to install libiconv

FYI: According to installation instructions, there may also be a cyclical install required: https://www.gnu.org/software/libiconv/

Might help issue #87, issue #20,
The gettext,libiconv, gettext install loop may help [#1918 UTF-16LE is not supported on libmtp-1.1.17 version.](https://sourceforge.net/p/libmtp/bugs/1918/).