### PR TITLE
Correct variable assignment in build configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,13 +28,13 @@ dnl we cannot do a 'make distcheck' with it as a non-root user, so
 dnl we need to skip INSTALL or UNINSTALL during 'make distcheck'.
 dnl Do this here since automake can't process 'if/else/endif in Makefile.am
 UDEVdata_SNIPPET='
-noinst_DATA = libmtp.fdi libmtp.usermap
+noinst_DATA="libmtp.fdi libmtp.usermap"
 ifeq ($(shell id -u),0)
-    udevrulesdir = $(UDEV)/rules.d
-    hwdbdir = $(UDEV)/hwdb.d
+    udevrulesdir=$(UDEV)/rules.d
+    hwdbdir=$(UDEV)/hwdb.d
 ifdef ENABLE_CROSSBUILD
-    udevrulesdir = $(TARGET_UDEV)/rules.d
-    hwdbdir = $(TARGET_UDEV)/hwdb.d
+    udevrulesdir=$(TARGET_UDEV)/rules.d
+    hwdbdir=$(TARGET_UDEV)/hwdb.d
 endif
 endif
 '
@@ -42,9 +42,9 @@ AC_SUBST([UDEVdata_SNIPPET])
 AM_SUBST_NOTMAKE([UDEVdata_SNIPPET])
 UDEVbin_SNIPPET='
 ifeq ($(shell id -u),0)
-    mtp_probedir = $(UDEV)
+    mtp_probedir=$(UDEV)
 ifdef ENABLE_CROSSBUILD
-    mtp_probedir = $(TARGET_UDEV)
+    mtp_probedir=$(TARGET_UDEV)
 endif
 endif
 '
@@ -128,7 +128,7 @@ if test "$crossbuilddir" != off; then
     fi
 fi
 AM_CONDITIONAL(ENABLE_CROSSBUILD,[test "$crossbuilddir" != off])
-TARGET_UDEV = ${crossbuilddir}
+TARGET_UDEV=${crossbuilddir}
 AC_SUBST(TARGET_UDEV)
 
 # Check for Darwin


### PR DESCRIPTION
Variable assignment results in shell code that should be invalid.  

Does throw errors [in existing automated builds](https://github.com/libmtp/libmtp/actions/runs/7339504216/job/19983852702#step:4:92):

```shell
checking for iconv... yes
checking for working iconv... yes
checking for iconv declaration... 
         extern size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);
checking for doxygen... false
./configure: line 14869: TARGET_UDEV: command not found
checking if the host operating system is Darwin... no
checking if the host operating system is Linux... yes
checking For MinGW32... no
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for libusb-1.0 >= 1.0.0... yes
checking for libgcrypt... checking for gcry_check_version in -lgcrypt... yes
```
.... however from a cursory glance I'm only seeing errors from the `TARGET_UDEV` instance, not the rest of the changes here. 