### PR TITLE
Add Lenovo Tablet P12 from different vendor IDs

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -3216,6 +3216,9 @@
   /* https://sourceforge.net/p/libmtp/feature-requests/259/ */
   { "Medion", 0x17ef, "P10606", 0xf003,
       DEVICE_FLAGS_ANDROID_BUGS },
+  /* https://github.com/libmtp/libmtp/issues/228 */
+  { "Lenovo", 0x17ef, "Tab P12", 0x7e16,
+      DEVICE_FLAGS_ANDROID_BUGS },
 
   /*
    * Huawei


### PR DESCRIPTION
Bug: https://github.com/libmtp/libmtp/issues/228