### PR TITLE
Add Rohde&Schwarz RTA4004 Oscilloscope

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4430,7 +4430,7 @@
   { "DJI", 0x2ca3, "Controller 2", 0x1021, DEVICE_FLAGS_ANDROID_BUGS },
 
   /* https://sourceforge.net/p/libmtp/bugs/1942/ */
-  { "Rohde&Schwarz", 0x00ad, "RTB2004", 0x01d7, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Rohde&Schwarz", 0x0aad, "RTx Oscilloscope", 0x01d7, DEVICE_FLAGS_ANDROID_BUGS },
 
   /* qemu 3.0.0 hw/usb/dev-mtp.c */
   { "QEMU", 0x46f4, "Virtual MTP", 0x0004, DEVICE_FLAG_NONE }


### PR DESCRIPTION
I'm hoping the `DEVICE_FLAGS_ANDROID_BUGS` flag is correct since it was set for the RTB2004 already in the database? If there's some way of testing, I can check it later.

Either way was able to get screenshots off of the scope with the device being `UNKOWN`, that is before this commit.