### PR TITLE
New device Garmin Epix Pro

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4033,6 +4033,7 @@
   { "Garmin", 0x091e, "Descent Mk2s (APAC)", 0x4f5a, DEVICE_FLAGS_ANDROID_BUGS }, /* APAC version */
   /* https://sourceforge.net/p/libmtp/support-requests/299/ */
   { "Garmin", 0x091e, "EPIX 2", 0x4f67, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Garmin", 0x091e, "EPIX Pro", 0x50d9, DEVICE_FLAGS_ANDROID_BUGS },    
   /* https://github.com/libmtp/libmtp/issues/150 */
   { "Garmin", 0x091e, "Forerunner 255M", 0x4f96, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/221 */


### PR DESCRIPTION
Added Garmin Epix Pro (Gen 2) [Smartwatch model](https://www.garmin.com/en-US/p/884088/pn/010-02804-00) to remedy  following error when connecting USB/MTP:


>: Device 0 (VID=091e and PID=50d9) is UNKNOWN in libmtp v1.1.21.
>: Please report this VID/PID and the device model to the libmtp development team 
>: LIBMTP PANIC: could not inspect object property description 0xba11!

 