### PR TITLE
util/mtp-hotplug.c: Enable stack memory protection

### DIFF
--- a/util/mtp-hotplug.c
+++ b/util/mtp-hotplug.c
@@ -354,5 +354,5 @@ int main (int argc, char **argv)
     printf("\n");
   }
 
-  exit (0);
+  return 0;
 }


### PR DESCRIPTION
Use "return 0" instead of "exit(0)" at the end of main() function to enable checking for Stack Overflow at Runtime.

Use "return 0" to let the program exit normally by returning from the main function. This allows the compiler to perform necessary cleanup operations, including stack canary checks.

__stack_chk_fail function isn't being invoked when using exit(0) at the end of the main function
$ objdump -T ./util/.libs/mtp-hotplug | grep __stack_chk_fail This return empty.