### PR TITLE
Add Garmin Edge 540

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4056,6 +4056,7 @@
   /* https://github.com/libmtp/libmtp/issues/146 */
   { "Garmin", 0x091e, "Forerunner 255S Music", 0x4f97, DEVICE_FLAGS_ANDROID_BUGS },
   { "Garmin", 0x091e, "Forerunner 955 Solar", 0x4fb8, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Garmin", 0x091e, "Edge 540", 0x4fdd, DEVICE_FLAGS_ANDROID_BUGS },
   { "Garmin", 0x091e, "Edge 840", 0x4fde, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/202 */
   { "Garmin", 0x091e, "Venu SQ 2 Music", 0x5014, DEVICE_FLAGS_ANDROID_BUGS },


### PR DESCRIPTION
```shell
lsusb | grep -i garmin
Bus 004 Device 013: ID 091e:4fdd Garmin International Edge 540
```

and after applying my change I get:
```shell
LD_PRELOAD=/home/glefalher/lib/libmtp.so jmtpfs ~/mtp/
Device 0 (VID=091e and PID=4fdd) is a Garmin Edge 540.
```