### PR TITLE
Fix -Wcalloc-transposed-args compiler warnings

### DIFF
--- a/src/ptp-pack.c
+++ b/src/ptp-pack.c
@@ -3125,7 +3125,7 @@ ptp_unpack_ptp11_manifest (
 		return 0;
 	numberoifs = dtoh64ap(params,data);
 	curoffset = 8;
-	xoifs = calloc(sizeof(PTPObjectFilesystemInfo),numberoifs);
+	xoifs = calloc(numberoifs,sizeof(PTPObjectFilesystemInfo));
 	if (!xoifs)
 		return 0;
 

--- a/src/ptp.c
+++ b/src/ptp.c
@@ -5329,7 +5329,7 @@ ptp_fuji_getdeviceinfo (PTPParams* params, uint16_t **props, unsigned int *numpr
 	nums = dtoh32a(data);
 	xdata = data + 4;
 
-	*props = calloc(sizeof(uint16_t),nums);
+	*props = calloc(nums,sizeof(uint16_t));
 	*numprops = nums;
 	for (i=0;i<nums;i++) {
 		PTPDevicePropDesc	dpd;


### PR DESCRIPTION
This commit fixes the following warnings from GCC 14.2.1:
```
ptp-pack.c: In function 'ptp_unpack_ptp11_manifest':
ptp-pack.c:3128:31: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 3128 |         xoifs = calloc(sizeof(PTPObjectFilesystemInfo),numberoifs);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~
ptp-pack.c:3128:31: note: earlier argument should specify number of elements, later size of each element

ptp.c: In function 'ptp_fuji_getdeviceinfo':
ptp.c:5332:32: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 5332 |         *props = calloc(sizeof(uint16_t),nums);
      |                                ^~~~~~~~
ptp.c:5332:32: note: earlier argument should specify number of elements, later size of each element
```

Similar changes: https://github.com/gphoto/libgphoto2/commit/67ae87e169e20d9dccec961ed5dad8cefae68a4f