### PR TITLE
Fix LIBMTP_Get_Supported_Filetypes leak when running mtp-detect

### DIFF
--- a/examples/detect.c
+++ b/examples/detect.c
@@ -187,6 +187,7 @@ int main (int argc, char **argv)
       for (i = 0; i < filetypes_len; i++) {
 	fprintf(stdout, "   %s\n", LIBMTP_Get_Filetype_Description(filetypes[i]));
       }
+      LIBMTP_FreeMemory(filetypes);
     } else {
       LIBMTP_Dump_Errorstack(device);
       LIBMTP_Clear_Errorstack(device);


### PR DESCRIPTION
This commit fixes the following leak when running `mtp-detect`:

```
Direct leak of 54 byte(s) in 1 object(s) allocated from:
    #0 0x7ad4452fd721 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7ad444de6855 in LIBMTP_Get_Supported_Filetypes src/libmtp.c:4086
    #2 0x623aed871500 in main examples/detect.c:182
```

Testing:
- No issues were detected when testing the patch with ASan, LSan, and UBSan