### PR TITLE
Ignore HP scanners https://github.com/libmtp/libmtp/issues/280

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -3584,7 +3584,7 @@
       DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/254 */
   { "SHARP", 0x0489, "AQUOS Wish3", 0xc033,
-      DEVICE_FLAGS_ANDROID_BUGS },    
+      DEVICE_FLAGS_ANDROID_BUGS },
   { "Foxconn (for Vizio)", 0x0489, "VTAB1008", 0xe040,
       DEVICE_FLAGS_ANDROID_BUGS },
   { "Foxconn (for Lenovo)", 0x0489, "IdeaTab A2109/A2110/Medion LIFETAB S9714", 0xe111,
@@ -3962,6 +3962,9 @@
   /* https://sourceforge.net/p/libmtp/bugs/1366/ */
   { "Hewlett-Packard", 0x03f0, "Slate 10 HD", 0x7e1d,
       DEVICE_FLAGS_ANDROID_BUGS },
+  /* https://github.com/libmtp/libmtp/issues/280 (NOTE:printer/scanner)
+  { "Hewlett-Packard", 0x03f0, "Color LaserJet Pro M478f-9f", 0xc52a,
+      DEVICE_something_something_flags }, */
 
   /*
    * MediaTek Inc.

--- a/util/mtp-hotplug.c
+++ b/util/mtp-hotplug.c
@@ -186,6 +186,8 @@ int main (int argc, char **argv)
       printf("ATTR{idVendor}==\"0971\", GOTO=\"libmtp_rules_end\"\n");
       printf("# Canon scanners that look like MTP devices (PID 0x22nn)\n");
       printf("ATTR{idVendor}==\"04a9\", ATTR{idProduct}==\"22*\", GOTO=\"libmtp_rules_end\"\n");
+      printf("# HP scanners that look like MTP devices (PID 0xc5nn)\n");
+      printf("ATTR{idVendor}==\"03f0\", ATTR{idProduct}==\"c5*\", GOTO=\"libmtp_rules_end\"\n");
       printf("# Canon digital camera (EOS 3D) that looks like MTP device (PID 0x3113)\n");
       printf("ATTR{idVendor}==\"04a9\", ATTR{idProduct}==\"3113\", GOTO=\"libmtp_rules_end\"\n");
       printf("# Sensitive Atheros devices that look like MTP devices\n");


### PR DESCRIPTION
Added 69-libmtp.rules rule similar to Cannon scanners # HP scanners that look like MTP devices (PID 0xc5nn) ATTR{idVendor}=="03f0", ATTR{idProduct}=="c5*", GOTO="libmtp_rules_end"

Also added (fully commented-out) reference in music-players.h in case more HP scanner-type devices are collected in future. This might be a USB storage device that might possibly be accessible.