### PR TITLE
autogen.sh, move 'touch config.rpath' before running aclocal

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ on:
       - 'LICENSES/*'
   schedule:
     - cron: '35 14 * * 1'
-    
+
 permissions:
   contents: read
 
@@ -70,6 +70,7 @@ jobs:
 
     # install automake and friends
     - run: sudo apt-get update && sudo apt-get install -y autopoint automake autoconf libtool
+    - run: sudo apt-get gettext
 
     # build and check
     - run: bash ./autogen.sh ; ./configure ; make ; make check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,9 @@ jobs:
 
     # install automake and friends
     - run: sudo apt-get update && sudo apt-get install -y autopoint automake autoconf libtool
-    - run: sudo apt-get gettext
+
+    # autogen.sh needs to check for and add these too....
+    - run: sudo apt-get install -y gettext libgcrypt-dev libusb-dev libusb-1.0-0-dev
 
     # build and check
     - run: bash ./autogen.sh ; ./configure ; make ; make check

--- a/autogen.sh
+++ b/autogen.sh
@@ -21,17 +21,11 @@ aclocal $ACLOCAL_FLAGS || fail
 
 # Refresh GNU autotools toolchain: autoconf
 echo "Removing autoconf cruft"
-rm -f configure config.guess config.sub
+rm -f configure config.guess config.sub ltmain.sh
 rm -rf autom4te*.cache/
 echo "Running autoconf"
 autoconf
-
-# Refresh GNU autotools toolchain: libtool
-echo "Removing libtool cruft"
-rm -f ltmain.sh
-echo "Running libtoolize"
-(glibtoolize --version) < /dev/null > /dev/null 2>&1 && LIBTOOLIZE=glibtoolize || LIBTOOLIZE=libtoolize
-$LIBTOOLIZE --copy --force || fail
+autoreconf -i
 
 echo "Removing autoheader cruft"
 rm -f config.h.in src/config.h.in

--- a/autogen.sh
+++ b/autogen.sh
@@ -21,7 +21,8 @@ $LIBTOOLIZE --copy --force || fail
 
 # Refresh GNU autotools toolchain: aclocal autoheader
 echo "Removing aclocal cruft"
-rm -f aclocal.m4
+rm -f aclocal.m4 config.rpath
+touch config.rpath
 echo "Running aclocal $ACLOCAL_FLAGS"
 aclocal $ACLOCAL_FLAGS || fail
 echo "Removing autoheader cruft"
@@ -34,7 +35,6 @@ echo "Removing automake cruft"
 rm -f depcomp install-sh missing mkinstalldirs
 rm -f stamp-h*
 echo "Running automake"
-touch config.rpath
 automake --add-missing --gnu || fail
 
 # Refresh GNU autotools toolchain: autoconf

--- a/autogen.sh
+++ b/autogen.sh
@@ -12,21 +12,18 @@ fail() {
     exit $status
 }
 
+# Refresh GNU autotools toolchain: libtool
+echo "Removing libtool cruft"
+rm -f ltmain.sh config.guess config.sub
+echo "Running libtoolize"
+(glibtoolize --version) < /dev/null > /dev/null 2>&1 && LIBTOOLIZE=glibtoolize || LIBTOOLIZE=libtoolize
+$LIBTOOLIZE --copy --force || fail
+
 # Refresh GNU autotools toolchain: aclocal autoheader
 echo "Removing aclocal cruft"
-rm -f aclocal.m4 config.rpath
-touch config.rpath
+rm -f aclocal.m4
 echo "Running aclocal $ACLOCAL_FLAGS"
 aclocal $ACLOCAL_FLAGS || fail
-
-# Refresh GNU autotools toolchain: autoconf
-echo "Removing autoconf cruft"
-rm -f configure config.guess config.sub ltmain.sh
-rm -rf autom4te*.cache/
-echo "Running autoconf"
-autoconf
-autoreconf -i
-
 echo "Removing autoheader cruft"
 rm -f config.h.in src/config.h.in
 echo "Running autoheader"
@@ -37,9 +34,17 @@ echo "Removing automake cruft"
 rm -f depcomp install-sh missing mkinstalldirs
 rm -f stamp-h*
 echo "Running automake"
+touch config.rpath
 automake --add-missing --gnu || fail
 
-# Autoupdate config.sub and config.guess 
+# Refresh GNU autotools toolchain: autoconf
+echo "Removing autoconf cruft"
+rm -f configure
+rm -rf autom4te*.cache/
+echo "Running autoconf"
+autoconf
+
+# Autoupdate config.sub and config.guess
 # from GNU CVS
 WGET=`which wget`
 if [ "x$WGET" != "x" ]; then

--- a/autogen.sh
+++ b/autogen.sh
@@ -19,9 +19,16 @@ touch config.rpath
 echo "Running aclocal $ACLOCAL_FLAGS"
 aclocal $ACLOCAL_FLAGS || fail
 
+# Refresh GNU autotools toolchain: autoconf
+echo "Removing autoconf cruft"
+rm -f configure config.guess config.sub
+rm -rf autom4te*.cache/
+echo "Running autoconf"
+autoconf
+
 # Refresh GNU autotools toolchain: libtool
 echo "Removing libtool cruft"
-rm -f ltmain.sh config.guess config.sub
+rm -f ltmain.sh
 echo "Running libtoolize"
 (glibtoolize --version) < /dev/null > /dev/null 2>&1 && LIBTOOLIZE=glibtoolize || LIBTOOLIZE=libtoolize
 $LIBTOOLIZE --copy --force || fail
@@ -37,13 +44,6 @@ rm -f depcomp install-sh missing mkinstalldirs
 rm -f stamp-h*
 echo "Running automake"
 automake --add-missing --gnu || fail
-
-# Refresh GNU autotools toolchain: autoconf
-echo "Removing autoconf cruft"
-rm -f configure
-rm -rf autom4te*.cache/
-echo "Running autoconf"
-autoconf
 
 # Autoupdate config.sub and config.guess 
 # from GNU CVS

--- a/autogen.sh
+++ b/autogen.sh
@@ -12,6 +12,13 @@ fail() {
     exit $status
 }
 
+# Refresh GNU autotools toolchain: aclocal autoheader
+echo "Removing aclocal cruft"
+rm -f aclocal.m4 config.rpath
+touch config.rpath
+echo "Running aclocal $ACLOCAL_FLAGS"
+aclocal $ACLOCAL_FLAGS || fail
+
 # Refresh GNU autotools toolchain: libtool
 echo "Removing libtool cruft"
 rm -f ltmain.sh config.guess config.sub
@@ -19,12 +26,6 @@ echo "Running libtoolize"
 (glibtoolize --version) < /dev/null > /dev/null 2>&1 && LIBTOOLIZE=glibtoolize || LIBTOOLIZE=libtoolize
 $LIBTOOLIZE --copy --force || fail
 
-# Refresh GNU autotools toolchain: aclocal autoheader
-echo "Removing aclocal cruft"
-rm -f aclocal.m4 config.rpath
-touch config.rpath
-echo "Running aclocal $ACLOCAL_FLAGS"
-aclocal $ACLOCAL_FLAGS || fail
 echo "Removing autoheader cruft"
 rm -f config.h.in src/config.h.in
 echo "Running autoheader"


### PR DESCRIPTION
CodeQuality pointed to a problem not finding config.rpath while running autogen.sh
