### PR TITLE
codeql - added packages needed to run codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ on:
       - 'LICENSES/*'
   schedule:
     - cron: '35 14 * * 1'
-    
+
 permissions:
   contents: read
 
@@ -70,6 +70,9 @@ jobs:
 
     # install automake and friends
     - run: sudo apt-get update && sudo apt-get install -y autopoint automake autoconf libtool
+
+    # install other packages needed to build complete libmtp
+    sudo apt-get install -y gettext libgcrypt-dev libusb-1.0-0-dev
 
     # build and check
     - run: bash ./autogen.sh ; ./configure ; make ; make check

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 #set -e
 
+# Before running autogen.sh, you wil need to install: autopoint automake autoconf libtool
+# and the developer versions for: libgcrypt-dev libusb-1.0-0-dev
+# and also the developer version of: libiconv (this may also be within 'gettext' for some distros).
+
 srcdir=`dirname $0`
 
 ACLOCAL_FLAGS="-I ${srcdir}/m4 ${ACLOCAL_FLAGS}"
@@ -44,7 +48,7 @@ rm -rf autom4te*.cache/
 echo "Running autoconf"
 autoconf
 
-# Autoupdate config.sub and config.guess 
+# Autoupdate config.sub and config.guess
 # from GNU CVS
 WGET=`which wget`
 if [ "x$WGET" != "x" ]; then


### PR DESCRIPTION
Attempted to understand why codeql was failing early in https://github.com/libmtp/libmtp/pull/287, this pull request allows codeql to run a bit further.