### PR TITLE
Added Garmin fenix 8 solar sapphire

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4142,6 +4142,7 @@
   { "Garmin", 0x091e, "Fenix8", 0x51b6, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/251 */
   { "Garmin", 0x091e, "Fenix 8 AMOLED", 0x51b8, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Garmin", 0x091e, "Fenix 8 Solar Sapphire", 0x51b5, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/207 */
   { "Garmin", 0x091e, "Tactix 7 AMOLED", 0x51be, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/305 */


### PR DESCRIPTION
This pull request adds the fenix 8 solar to libmtp.