### PR TITLE
fix macos autopoint problem during unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Create configure
         run: |
-          brew install autoconf automake libtool gcc libgcrypt libiconv gettext autopoint
+          brew install autoconf automake libtool gcc libgcrypt libiconv gettext
+          ln -s `brew ls gettext | grep bin/autopoint` /usr/local/bin
           bash autogen.sh
       - name: Choose configure option(s)
         run: ./configure ${{ matrix.choiceM }}


### PR DESCRIPTION
local mac gettext version missing autopoint, so we link to brew autopoint as per symlink information provided for pinfo-on-os-x shown on help webpage here:
https://superuser.com/questions/990602/compiling-pinfo-on-os-x

ln -s `brew ls gettext | grep bin/autopoint` /usr/local/bin

The test now halts further along, now in ./configure which indicates installed gettext version on macos appears to be 0.26, so it looks like configure.ac will need upgrading from 0.11 to work for macos unit test to pass.