### PR TITLE
mtp-hotplug: blacklist Sennheiser/EPOS ADAPT 160 ANC (1395:0280)

### DIFF
--- a/util/mtp-hotplug.c
+++ b/util/mtp-hotplug.c
@@ -200,6 +200,8 @@ int main (int argc, char **argv)
       printf("ATTR{idVendor}==\"1db2\", ATTR{idProduct}==\"060*\", GOTO=\"libmtp_rules_end\"\n");
       printf("# Printers\n");
       printf("ENV{ID_USB_INTERFACES}==\"*:0701??:*\", GOTO=\"libmtp_rules_end\"\n");
+      printf("# Sennheiser/EPOS ADAPT 160 ANC\n");
+      printf("ATTR{idVendor}==\"1395\", ATTR{idProduct}==\"0280\", GOTO=\"libmtp_rules_end\"\n");
       break;
     case style_udev_fast:
     case style_udev_old:


### PR DESCRIPTION
Avoid probing the EPOS ADAPT 160 ANC (USB ID 1395:0280), since this causes the device firmware to hang. Once this happens, the snd-usb-audio driver fails to initialize the device and reports a "usb_set_interface failed (-110)" timeout in dmesg.