### PR TITLE
Add Garmin Venu X1 to music-players.h

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4158,11 +4158,11 @@
   { "Garmin", 0x091e, "Forerunner 970", 0x51d5, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/302 */
   { "Garmin", 0x091e, "Forerunner 570", 0x51de, DEVICE_FLAGS_ANDROID_BUGS },
+  { "Garmin", 0x091e, "Venu X1", 0x51fb, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/303 */
   { "Garmin", 0x091e, "Vivoactive 6", 0x5211, DEVICE_FLAGS_ANDROID_BUGS },
   { "Garmin", 0x091e, "Edge 850", 0x521a, DEVICE_FLAGS_ANDROID_BUGS },
   { "Garmin", 0x091e, "Venu 4 - 41mm", 0x5224, DEVICE_FLAGS_ANDROID_BUGS },
-  { "Garmin", 0x091e, "Venu X1", 0x52fb, DEVICE_FLAGS_ANDROID_BUGS },
   /* https://github.com/libmtp/libmtp/issues/309 */
   { "Garmin", 0x091e, "Instinct 3 Solar", 0x5297, DEVICE_FLAGS_ANDROID_BUGS },
 


### PR DESCRIPTION
This change adds VID=091e PID=51fb to music-players.h to support the Garmin Venu X1.