### PR TITLE
fix handling of missing const type qualifier

### DIFF
--- a/src/libmtp.c
+++ b/src/libmtp.c
@@ -5713,7 +5713,7 @@ static int check_filename_exists(PTPParams* params, char const * const filename)
 static char *generate_unique_filename(PTPParams* params, char const * const filename)
 {
   int suffix;
-  char * extension_position;
+  const char * extension_position;
 
   if (check_filename_exists(params, filename))
   {


### PR DESCRIPTION
For ISO C23, the function strrchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

Update to const type for variable, as returned string is only used in comparisons which const can be used