### PR TITLE
Add support for Ricoh GR IV (VID=0x25fb, PID=0x2123)

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4413,6 +4413,8 @@
    */
   { "Ricoh", 0x05ca, "Theta V (MTP)", 0x0368, DEVICE_FLAG_NONE },
   { "Ricoh", 0x05ca, "Theta Z1 (MTP)", 0x036d, DEVICE_FLAG_NONE },
+  /* https://github.com/libmtp/libmtp/issues/392 */
+  { "Ricoh", 0x25fb, "GR IV", 0x2123, DEVICE_FLAG_NONE },
 
   /* https://sourceforge.net/p/libmtp/bugs/1490/ */
   { "Marshall" , 0x2ad9, "London", 0x000b, DEVICE_FLAG_NONE },


### PR DESCRIPTION
## Summary

- Added device entry for the **Ricoh GR IV** digital camera (VID=`0x25fb`, PID=`0x2123`) to the device table in `music-players.h`.
- The camera presents itself as an MTP/PTP device (USB class 06/still image, subclass 01/PTP, protocol 01) but was not recognized by libmtp, falling back to generic mode and causing DNG RAW file transfer failures.

Fixes: #392

## Test plan

- [ ] Verify the Ricoh GR IV is recognized as an MTP device after building/installing
- [ ] Verify file transfers (including DNG RAW) work correctly via GVFS/MTP