### PR TITLE
Fix integer overflow in ptp_canon_getobjectinfo()

### DIFF
--- a/src/ptp.c
+++ b/src/ptp.c
@@ -4130,6 +4130,10 @@ ptp_canon_getobjectinfo (PTPParams* params, uint32_t store, uint32_t p2,
 	}
 
 	*entnum = ptp.Param1;
+	if (*entnum > SIZE_MAX / sizeof(PTPCANONFolderEntry)) {
+		ptp_debug (params, "param1 is %d, overflow", ptp.Param1);
+		goto error;
+	}
 	*entries= calloc(*entnum, sizeof(PTPCANONFolderEntry));
 	if (*entries == NULL)
 		goto error;


### PR DESCRIPTION
## Summary
- Fix heap-based buffer overflow in `ptp_canon_getobjectinfo()` caused by integer overflow in `calloc()` size calculation (fixes #369)
- Add `SIZE_MAX / sizeof(PTPCANONFolderEntry)` check before allocation to prevent wraparound on 32-bit systems

A malicious PTP device can control `Param1` and `size` to trigger an undersized allocation followed by heap overflow.

## Test plan
- [ ] Verify compilation passes
- [ ] Review that the overflow guard is placed before the existing `calloc()` call
- [ ] Confirm existing `Param1 > size/PTP_CANON_FolderEntryLen` check remains intact