### PR TITLE
Add support for HumanWare Victor Stream 3

### DIFF
--- a/src/music-players.h
+++ b/src/music-players.h
@@ -4582,3 +4582,6 @@
 
   /* qemu 3.0.0 hw/usb/dev-mtp.c */
   { "QEMU", 0x46f4, "Virtual MTP", 0x0004, DEVICE_FLAG_NONE }
+
+  /* https://github.com/libmtp/libmtp/issues/389 */
+  { "HumanWare", 0x1c71, "Stream 3 (Victor Reader Stream)", 0xc150, DEVICE_FLAGS_ANDROID_BUGS }


### PR DESCRIPTION
## Summary
- Add device entry for HumanWare Victor Stream 3 (VID=0x1c71, PID=0xc150) (fixes #389)
- Device identifies as Android MTP with `android.com: 1.0` extension, uses standard Android bug flags

Device info from mtp-detect:
- Manufacturer: Humanware
- Model: Stream V3
- Vendor extension: microsoft.com: 1.0; android.com: 1.0;
- Detected object size: 64 bits
- Storage: internal RAM + SD card

## Test plan
- [ ] Verify compilation passes
- [ ] Confirm device flags match the auto-detected flags from mtp-detect output in the issue